### PR TITLE
CSTC - v1.3.5

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -29,7 +29,7 @@ jobs:
         java-version: 17
 
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
         java-version: 17
 
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.5] - 2025-03-17
+
+### Added
+
+* Add Remove HTTP Header Operation
+
+### Changed
+
+* Refactor Send Plain Request Operation
+* Refactor Request Builder Operation to allow all HTTP verbs
+* Refactor Set HTTP Cookie Operation
+* Refactor HTTP Cookie Extractor Operation
+* Refactor HTML Encode Operation
+* Refactor HTML Decode Operation
+* Refactor HTTP Body Extractor Operation
+* Refactor Substring Operation
+* Change Recipe Panel to bake empty input
+* Change multiple operations to handle empty input
+* Change context menu items to not bake recipes when selected
+* Refactor Operations Tree to be the same for all Recipe Panel
+* Change operations perform method to parse the message type of its input
+* Add checkbox to Write File Operation to make the new line optional
+
+### Fixed 
+
+* Fix several issues in relation of missing JSON fields in dated recipes
+* Fix recipes being applied again on requests originating from the recipe itself (analog with responses) 
+* Fix Request Builder Operation to add trailing line breaks 
+* Fix logic error in JWT Sign Operation 
+* Fix operations output Null Byte if an exception is thrown
+
+
 ## [1.3.4] - 2024-11-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-*Copyright 2017-2024 usd AG*
+*Copyright 2017-2025 usd AG*
 
 Licensed under the *GNU General Public License, Version 3.0* (the "License"). You may not use this tool except in compliance with the License.
 You may obtain a copy of the License at https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Currently the Burp Montoya API doesn't offer a way to change this order automati
 
 ### What is the *Formatting* tab in the CSTC about?
 
-The *CSTC Formatting* tab is available in all of Burp's HTTP message ditors and shows the result of applying the recipe currently defined in *Formatting* to the content. It has purely a visual effect, the underlying message is not changed. It is intended for testing recipes and for temporarily visualizing changes to the HTTP message using the operations available in the CSTC. 
+The *CSTC Formatting* tab is available in all of Burp's HTTP message editors and shows the result of applying the recipe currently defined in *Formatting* to the content. It has purely a visual effect, the underlying message is not changed. It is intended for testing recipes and for temporarily visualizing changes to the HTTP message using the operations available in the CSTC.
 
 Only the HTTP request message editor in the *Repeater* has an additional tab called *CSTC*. Here, the recipe currently defined in *Outgoing* is applied to the request, making it visible how the request is sent to the server **if** the CSTC is activated for the *Repeater*.
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Depending on the extensions in use, it may make sense to adjust the position of 
 the CSTC should be positioned above this extension. Conversely, the CSTC should be positioned below an extension if the CSTC is to work with the response processed by the extension in question.
 Currently the Burp Montoya API doesn't offer a way to change this order automatically, therefore the CSTC cannot influence the interaction with other extensions itself.
 
-### What tabs are added to Burp's HTTP message editor and how can they be used?
+### What is the *Formatting* tab in the CSTC about?
 
-The *CSTC Formatting* tab is available in all Burp's own tools and shows the result of applying the recipe currently defined in *Formatting* to the request or response. It has no actual effect on either of them. It is intended for testing recipes and for temporarily visualizing changes to the HTTP message using the operations available in the CSTC.
+The *CSTC Formatting* tab is available in all of Burp's HTTP message ditors and shows the result of applying the recipe currently defined in *Formatting* to the content. It has purely a visual effect, the underlying message is not changed. It is intended for testing recipes and for temporarily visualizing changes to the HTTP message using the operations available in the CSTC. 
 
 Only the HTTP request message editor in the *Repeater* has an additional tab called *CSTC*. Here, the recipe currently defined in *Outgoing* is applied to the request, making it visible how the request is sent to the server **if** the CSTC is activated for the *Repeater*.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Depending on the extensions in use, it may make sense to adjust the position of 
 the CSTC should be positioned above this extension. Conversely, the CSTC should be positioned below an extension if the CSTC is to work with the response processed by the extension in question.
 Currently the Burp Montoya API doesn't offer a way to change this order automatically, therefore the CSTC cannot influence the interaction with other extensions itself.
 
+### What tabs are added to Burp's HTTP message editor and how can they be used?
+
+The *CSTC Formatting* tab is available in all Burp's own tools and shows the result of applying the recipe currently defined in *Formatting* to the request or response. It has no actual effect on either of them. It is intended for testing recipes and for temporarily visualizing changes to the HTTP message using the operations available in the CSTC.
+
+Only the HTTP request message editor in the *Repeater* has an additional tab called *CSTC*. Here, the recipe currently defined in *Outgoing* is applied to the request, making it visible how the request is sent to the server **if** the CSTC is activated for the *Repeater*.
+
 ## Feedback
 
 We gladly appreciate all feedback, bug reports and feature requests.

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 			
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
+				<version>3.14.0</version>
 				<configuration>
 					<source>17</source>
 					<target>17</target>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.12.0</version>
+			<version>1.13.0</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>net.portswigger.burp.extensions</groupId>
 			<artifactId>montoya-api</artifactId>
-			<version>2024.7</version>
+			<version>2024.11</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.2</version>
+			<version>2.18.3</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 		    <groupId>com.auth0</groupId>
 		    <artifactId>java-jwt</artifactId>
-		    <version>4.4.0</version>
+		    <version>4.5.0</version>
 		</dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.1</version>
+			<version>2.18.2</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.usd.CSTC</groupId>
 	<artifactId>CSTC</artifactId>
-	<version>1.3.4</version>
+	<version>1.3.5</version>
 	<name>CSTC</name>
 	<description>CSTC</description>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.18.1</version>
+			<version>2.18.2</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.79</version>
+			<version>1.80</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.78</version>
+			<version>1.79</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.18.2</version>
+			<version>2.18.3</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>net.portswigger.burp.extensions</groupId>
 			<artifactId>montoya-api</artifactId>
-			<version>2024.12</version>
+			<version>2025.2</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>net.portswigger.burp.extensions</groupId>
 			<artifactId>montoya-api</artifactId>
-			<version>2024.11</version>
+			<version>2024.12</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.2</version>
                 <configuration>
         		  <trimStackTrace>false</trimStackTrace>
 				  <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -55,7 +55,7 @@ public class BurpExtender implements BurpExtension {
             view.preventRaceConditionOnVariables();
         } catch (Exception e) {
             Logger.getInstance().log(
-                    "Could not restore the filter state. If this is the first time using CSTC in a project, you can ignore this message. " + e.getMessage());
+                    "Could not restore the filter state. If this is the first time using CSTC in a project, you can ignore this message. ");
         }
     }
 }

--- a/src/main/java/burp/CstcHttpHandler.java
+++ b/src/main/java/burp/CstcHttpHandler.java
@@ -1,5 +1,6 @@
 package burp;
 
+import burp.api.montoya.core.Annotations;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.handler.HttpHandler;
 import burp.api.montoya.http.handler.HttpRequestToBeSent;
@@ -27,11 +28,12 @@ public class CstcHttpHandler implements HttpHandler {
 
     @Override
     public RequestToBeSentAction handleHttpRequestToBeSent(HttpRequestToBeSent requestToBeSent) {
+        if(requestToBeSent.toolSource().isFromTool(EXTENSIONS) && requestToBeSent.hasHeader("X-CSTC-79301f837932346cb067c568e27369bf")) {
+            ByteArray request = requestToBeSent.withRemovedHeader("X-CSTC-79301f837932346cb067c568e27369bf").toByteArray();
+            return continueWith(HttpRequest.httpRequest(request).withService(requestToBeSent.httpService()), Annotations.annotations("CSTC"));
+        }
+
         if (BurpUtils.getInstance().getFilterState().shouldProcess(FilterState.BurpOperation.OUTGOING, requestToBeSent.toolSource().toolType())) {
-            if(requestToBeSent.hasHeader("X-CSTC-79301f837932346cb067c568e27369bf") && requestToBeSent.toolSource().isFromTool(EXTENSIONS)) {
-                ByteArray request = requestToBeSent.withRemovedHeader("X-CSTC-79301f837932346cb067c568e27369bf").toByteArray();
-                return continueWith(HttpRequest.httpRequest(request).withService(requestToBeSent.httpService()));
-            }
 
             ByteArray request = requestToBeSent.toByteArray();
             ByteArray modifiedRequest = view.getOutgoingRecipePanel().bake(request, MessageType.REQUEST);
@@ -45,6 +47,9 @@ public class CstcHttpHandler implements HttpHandler {
     @Override
     public ResponseReceivedAction handleHttpResponseReceived(HttpResponseReceived responseReceived) {
         if (BurpUtils.getInstance().getFilterState().shouldProcess(FilterState.BurpOperation.INCOMING, responseReceived.toolSource().toolType())) {
+            if(responseReceived.annotations().hasNotes() && responseReceived.annotations().notes().equals("CSTC")) {
+                return continueWith(responseReceived);
+            }
             ByteArray response = responseReceived.toByteArray();
             ByteArray modifiedResponse = view.getIncomingRecipePanel().bake(response, MessageType.RESPONSE);
             return continueWith(HttpResponse.httpResponse(modifiedResponse));

--- a/src/main/java/burp/objects/CstcByteArray.java
+++ b/src/main/java/burp/objects/CstcByteArray.java
@@ -40,6 +40,11 @@ public class CstcByteArray implements ByteArray{
     }
 
     @Override
+    public int length() {
+        return bytes.length;
+    }
+
+    @Override
     public Iterator<Byte> iterator() {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'iterator'");
@@ -79,12 +84,6 @@ public class CstcByteArray implements ByteArray{
     public void setBytes(int index, ByteArray byteArray) {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'setBytes'");
-    }
-
-    @Override
-    public int length() {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'length'");
     }
 
     @Override

--- a/src/main/java/burp/objects/CstcHttpRequest.java
+++ b/src/main/java/burp/objects/CstcHttpRequest.java
@@ -484,5 +484,17 @@ public class CstcHttpRequest implements HttpRequest {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'withDefaultHeaders'");
     }
+
+    @Override
+    public ParsedHttpParameter parameter(String arg0) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'parameter'");
+    }
+
+    @Override
+    public String parameterValue(String arg0) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'parameterValue'");
+    }
     
 }

--- a/src/main/java/burp/objects/CstcHttpRequest.java
+++ b/src/main/java/burp/objects/CstcHttpRequest.java
@@ -107,7 +107,7 @@ public class CstcHttpRequest implements HttpRequest {
                         }
                     }
 
-                    throw new IllegalArgumentException("Input is not a vlaid request");
+                    throw new IllegalArgumentException("Input is not a valid request");
                 }
             case XML:
                 String postBody = request.split("\n\n")[1].trim();
@@ -135,6 +135,18 @@ public class CstcHttpRequest implements HttpRequest {
 
         String url = request.split("\\s")[1];
         return url;
+    }
+
+    @Override
+    public boolean hasHeader(String name) {
+        try {
+            headerValue(name);
+        }
+        catch(IllegalArgumentException e) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -223,12 +235,6 @@ public class CstcHttpRequest implements HttpRequest {
 
     @Override
     public boolean hasHeader(HttpHeader header) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'hasHeader'");
-    }
-
-    @Override
-    public boolean hasHeader(String name) {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'hasHeader'");
     }

--- a/src/main/java/burp/objects/CstcHttpResponse.java
+++ b/src/main/java/burp/objects/CstcHttpResponse.java
@@ -44,7 +44,6 @@ public class CstcHttpResponse implements HttpResponse {
     @Override
     public List<Cookie> cookies() {
         List<Cookie> cookieList = new ArrayList<>();
-        String cookies = new String();
 
         byte[] responseBytes = this.httpResponse.getBytes();
         String response = new String(responseBytes);
@@ -53,14 +52,9 @@ public class CstcHttpResponse implements HttpResponse {
         for(String line : responseLines) {
             String[] header = line.split(": ");
             if(header[0].equals("Set-Cookie")) {
-                cookies = header[1];
+                String[] cookie = header[1].split("=");
+                cookieList.add(new CstcCookie(cookie[0], cookie[1]));
             }
-        }
-
-        for(String cookie : cookies.split("; ")) {
-            String[] c = cookie.split("=");
-            Cookie cc = new CstcCookie(c[0], c[1]);
-            cookieList.add(cc);
         }
 
         return cookieList;
@@ -91,6 +85,18 @@ public class CstcHttpResponse implements HttpResponse {
     }
 
     @Override
+    public String cookieValue(String name) {
+        List<Cookie> cookies = this.cookies();
+        for(Cookie c : cookies) {
+            if(c.name().equals(name)) {
+                return c.value();
+            }
+        }
+        
+        return null;
+    }
+
+    @Override
     public short statusCode() {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'statusCode'");
@@ -112,12 +118,6 @@ public class CstcHttpResponse implements HttpResponse {
     public Cookie cookie(String name) {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'cookie'");
-    }
-
-    @Override
-    public String cookieValue(String name) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'cookieValue'");
     }
 
     @Override

--- a/src/main/java/de/usd/cstchef/Utils.java
+++ b/src/main/java/de/usd/cstchef/Utils.java
@@ -126,7 +126,7 @@ import de.usd.cstchef.operations.hashing.Skein;
 import de.usd.cstchef.operations.hashing.Tiger;
 import de.usd.cstchef.operations.hashing.Luhn;
 import de.usd.cstchef.operations.hashing.Whirlpool;
-import de.usd.cstchef.operations.misc.GetRequestBuilder;
+import de.usd.cstchef.operations.misc.RequestBuilder;
 import de.usd.cstchef.operations.misc.ReadFile;
 import de.usd.cstchef.operations.misc.WriteFile;
 import de.usd.cstchef.operations.networking.PlainRequest;
@@ -390,7 +390,7 @@ public class Utils {
                 Addition.class, AddKey.class, AesDecryption.class, AesEncryption.class, And.class,
                 Blake.class, Counter.class, DateTime.class, Deflate.class, DesDecryption.class, DesEncryption.class,
                 Divide.class, DivideList.class, DSTU7564.class, FromBase64.class, FromHex.class,
-                GetRequestBuilder.class,
+                RequestBuilder.class,
                 GetVariable.class, Gost.class, GUnzip.class, Gzip.class, Hmac.class,
                 HttpBodyExtractor.class, HttpCookieExtractor.class, HttpGetExtractor.class,
                 HttpGetSetter.class, HttpHeaderExtractor.class, HttpHeaderSetter.class,
@@ -423,7 +423,7 @@ public class Utils {
         return new Class[] {
                 Addition.class, AddKey.class, AesDecryption.class, AesEncryption.class, And.class,
                 Blake.class, Counter.class, DateTime.class, Deflate.class, DesDecryption.class, DesEncryption.class,
-                Divide.class, DivideList.class, DSTU7564.class, FromBase64.class, FromHex.class, GetRequestBuilder.class,
+                Divide.class, DivideList.class, DSTU7564.class, FromBase64.class, FromHex.class, RequestBuilder.class,
                 GetVariable.class, Gost.class, GUnzip.class, Gzip.class, Hmac.class, HttpBodyExtractor.class, 
                 HttpCookieExtractor.class, HttpHeaderExtractor.class, HttpHeaderSetter.class, HttpJsonExtractor.class,
                 HttpJsonSetter.class, HttpMultipartExtractor.class, HttpMultipartSetter.class, PlainRequest.class,

--- a/src/main/java/de/usd/cstchef/Utils.java
+++ b/src/main/java/de/usd/cstchef/Utils.java
@@ -130,6 +130,7 @@ import de.usd.cstchef.operations.misc.RequestBuilder;
 import de.usd.cstchef.operations.misc.ReadFile;
 import de.usd.cstchef.operations.misc.WriteFile;
 import de.usd.cstchef.operations.networking.PlainRequest;
+import de.usd.cstchef.operations.setter.HttpHeaderRemove;
 import de.usd.cstchef.operations.setter.HttpGetSetter;
 import de.usd.cstchef.operations.setter.HttpHeaderSetter;
 import de.usd.cstchef.operations.setter.HttpJsonSetter;
@@ -393,7 +394,7 @@ public class Utils {
                 RequestBuilder.class,
                 GetVariable.class, Gost.class, GUnzip.class, Gzip.class, Hmac.class,
                 HttpBodyExtractor.class, HttpCookieExtractor.class, HttpGetExtractor.class,
-                HttpGetSetter.class, HttpHeaderExtractor.class, HttpHeaderSetter.class,
+                HttpGetSetter.class, HttpHeaderExtractor.class, HttpHeaderSetter.class, HttpHeaderRemove.class,
                 HttpJsonExtractor.class, HttpJsonSetter.class, HttpMethodExtractor.class, HttpMultipartExtractor.class,
                 HttpMultipartSetter.class,
                 HttpPostExtractor.class, HttpPostSetter.class, PlainRequest.class, HttpSetBody.class,
@@ -425,7 +426,7 @@ public class Utils {
                 Blake.class, Counter.class, DateTime.class, Deflate.class, DesDecryption.class, DesEncryption.class,
                 Divide.class, DivideList.class, DSTU7564.class, FromBase64.class, FromHex.class, RequestBuilder.class,
                 GetVariable.class, Gost.class, GUnzip.class, Gzip.class, Hmac.class, HttpBodyExtractor.class, 
-                HttpCookieExtractor.class, HttpHeaderExtractor.class, HttpHeaderSetter.class, HttpJsonExtractor.class,
+                HttpCookieExtractor.class, HttpHeaderExtractor.class, HttpHeaderSetter.class, HttpHeaderRemove.class, HttpJsonExtractor.class,
                 HttpJsonSetter.class, HttpMultipartExtractor.class, HttpMultipartSetter.class, PlainRequest.class,
                 HttpSetBody.class, HttpSetCookie.class, HttpXmlExtractor.class, HttpXmlSetter.class, XmlSetter.class, HtmlEncode.class,
                 HtmlDecode.class, Inflate.class, JsonExtractor.class, JsonSetter.class, JWTDecode.class, JWTSign.class,

--- a/src/main/java/de/usd/cstchef/Utils.java
+++ b/src/main/java/de/usd/cstchef/Utils.java
@@ -386,7 +386,7 @@ public class Utils {
 
     // TODO reflection does not work in Burp Suite
     @SuppressWarnings("unchecked")
-    public static Class<? extends Operation>[] getOperationsDevOutgoingFormatting() {
+    public static Class<? extends Operation>[] getOperationsDev() {
         return new Class[] {
                 Addition.class, AddKey.class, AesDecryption.class, AesEncryption.class, And.class,
                 Blake.class, Counter.class, DateTime.class, Deflate.class, DesDecryption.class, DesEncryption.class,
@@ -418,39 +418,8 @@ public class Utils {
         };
     }
 
-    // TODO reflection does not work in Burp Suite
-    @SuppressWarnings("unchecked")
-    public static Class<? extends Operation>[] getOperationsDevIncoming() {
-        return new Class[] {
-                Addition.class, AddKey.class, AesDecryption.class, AesEncryption.class, And.class,
-                Blake.class, Counter.class, DateTime.class, Deflate.class, DesDecryption.class, DesEncryption.class,
-                Divide.class, DivideList.class, DSTU7564.class, FromBase64.class, FromHex.class, RequestBuilder.class,
-                GetVariable.class, Gost.class, GUnzip.class, Gzip.class, Hmac.class, HttpBodyExtractor.class, 
-                HttpCookieExtractor.class, HttpHeaderExtractor.class, HttpHeaderSetter.class, HttpHeaderRemove.class, HttpJsonExtractor.class,
-                HttpJsonSetter.class, HttpMultipartExtractor.class, HttpMultipartSetter.class, PlainRequest.class,
-                HttpSetBody.class, HttpSetCookie.class, HttpXmlExtractor.class, HttpXmlSetter.class, XmlSetter.class, HtmlEncode.class,
-                HtmlDecode.class, Inflate.class, JsonExtractor.class, JsonSetter.class, JWTDecode.class, JWTSign.class,
-                Length.class, LineExtractor.class, LineSetter.class, MD2.class, MD4.class, MD5.class, Mean.class, Median.class,
-                Multiply.class, MultiplyList.class, NoOperation.class, NumberCompare.class, Prefix.class, RandomNumber.class,
-                RandomUUID.class, ReadFile.class, RegexExtractor.class, Reverse.class, Replace.class,
-                RIPEMD.class, RsaDecryption.class, RsaEncryption.class, RsaSignature.class, SM2Signature.class, SM3.class,
-                SM4Encryption.class, SM4Decryption.class, RegexMatch.class, SetIfEmpty.class, SHA1.class, SHA2.class,
-                SHA3.class, Skein.class, SplitAndSelect.class, StaticString.class, StoreVariable.class, Sub.class, Substring.class,
-                Uppercase.class, Lowercase.class, Subtraction.class, Suffix.class, Sum.class, StringContains.class,
-                StringMatch.class, Tiger.class, TimestampOffset.class, TimestampToDateTime.class, ToBase64.class, ToHex.class,
-                UnixTimestamp.class, UrlDecode.class, UrlEncode.class, Whirlpool.class, WriteFile.class, XmlFullSignature.class,
-                XmlMultiSignature.class, Xor.class, SoapMultiSignature.class, Luhn.class, Concatenate.class, JsonBeautifier.class
-        };
-    }
-
-    public static Class<? extends Operation>[] getOperations(BurpOperation operation) {
-        //return BurpUtils.inBurp() ? Utils.getOperationsDev() : Utils.getOperationsDev();
-        if(operation == BurpOperation.INCOMING) {
-            return getOperationsDevIncoming();
-        }
-        else {
-            return getOperationsDevOutgoingFormatting();
-        }
+    public static Class<? extends Operation>[] getOperations() {
+        return Utils.getOperationsDev();
     }
 
     public enum MessageType {

--- a/src/main/java/de/usd/cstchef/Utils.java
+++ b/src/main/java/de/usd/cstchef/Utils.java
@@ -259,7 +259,7 @@ public class Utils {
             } catch (Exception e) {
 
                 if (!addIfNotPresent)
-                    throw new IllegalArgumentException("Key not found.");
+                    throw new IllegalArgumentException("Invalid key or path.");
 
                 String insertPath = path;
                 if (insertPath.equals("Insert-Path") || insertPath.equals(""))
@@ -269,7 +269,7 @@ public class Utils {
                     document = document.put(insertPath, key, value);
                     return  ByteArray.byteArray(document.jsonString());
                 } catch (Exception ex) {
-                    throw new IllegalArgumentException("Could not parse JSON from input");
+                    throw new IllegalArgumentException("Error parsing the input.");
                 }
             }
 

--- a/src/main/java/de/usd/cstchef/operations/Operation.java
+++ b/src/main/java/de/usd/cstchef/operations/Operation.java
@@ -410,10 +410,10 @@ public abstract class Operation extends JPanel {
             return result;
         } catch (EOFException e) {
             this.setErrorMessage(new EOFException("End of file"));
-            return factory.createByteArray(0);
+            return factory.createByteArray("");
         } catch (Throwable e) {
             this.setErrorMessage(e);
-            return factory.createByteArray(0);
+            return factory.createByteArray("");
         }
     }
 

--- a/src/main/java/de/usd/cstchef/operations/Operation.java
+++ b/src/main/java/de/usd/cstchef/operations/Operation.java
@@ -536,7 +536,7 @@ public abstract class Operation extends JPanel {
             return MessageType.RESPONSE;
         }
 
-        throw new IllegalArgumentException("Input is not a valid HTTP message");
+        throw new IllegalArgumentException("Input is not a valid HTTP message.");
     }
 
     public ByteArray parseRawMessage(ByteArray input) throws Exception{

--- a/src/main/java/de/usd/cstchef/operations/Operation.java
+++ b/src/main/java/de/usd/cstchef/operations/Operation.java
@@ -403,9 +403,9 @@ public abstract class Operation extends JPanel {
         return dim;
     }
 
-    public ByteArray performOperation(ByteArray input, MessageType messageType) {
+    public ByteArray performOperation(ByteArray input) {
         try {
-            ByteArray result = this.perform(input, messageType);
+            ByteArray result = this.perform(input);
             this.setErrorMessage(null);
             return result;
         } catch (EOFException e) {
@@ -513,7 +513,7 @@ public abstract class Operation extends JPanel {
         public OperationCategory category() default OperationCategory.MISC;
     }
 
-    protected abstract ByteArray perform(ByteArray input, MessageType messageType) throws Exception;
+    protected abstract ByteArray perform(ByteArray input) throws Exception;
 
     public void createUI() {
 
@@ -540,7 +540,7 @@ public abstract class Operation extends JPanel {
     }
 
     public ByteArray parseRawMessage(ByteArray input) throws Exception{
-        return perform(input, parseMessageType(input));
+        return perform(input);
     }
 
     private class NotifyChangeListener implements DocumentListener, ActionListener, ChangeListener {

--- a/src/main/java/de/usd/cstchef/operations/arithmetic/ArithmeticDelimiterOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/arithmetic/ArithmeticDelimiterOperation.java
@@ -6,7 +6,6 @@ import javax.swing.JComboBox;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Delimiter;
 import de.usd.cstchef.Utils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 
 public abstract class ArithmeticDelimiterOperation extends Operation
@@ -31,7 +30,7 @@ public abstract class ArithmeticDelimiterOperation extends Operation
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception
+    protected ByteArray perform(ByteArray input) throws Exception
     {
         String delimiter = getDelimiter().getValue();
         String[] lines = new String(input.getBytes()).split(delimiter);

--- a/src/main/java/de/usd/cstchef/operations/arithmetic/ArithmeticOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/arithmetic/ArithmeticOperation.java
@@ -4,7 +4,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JTextField;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 
 public abstract class ArithmeticOperation extends Operation
@@ -23,7 +22,7 @@ public abstract class ArithmeticOperation extends Operation
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception
+    protected ByteArray perform(ByteArray input) throws Exception
     {
         try
         {

--- a/src/main/java/de/usd/cstchef/operations/byteoperation/ByteKeyOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/byteoperation/ByteKeyOperation.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.byteoperation;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.view.ui.FormatTextField;
 
@@ -15,7 +14,7 @@ public abstract class ByteKeyOperation extends Operation  {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         ByteArray result = factory.createByteArray(input.length());
         ByteArray key = this.inputTxt.getText();

--- a/src/main/java/de/usd/cstchef/operations/compression/Deflate.java
+++ b/src/main/java/de/usd/cstchef/operations/compression/Deflate.java
@@ -6,7 +6,6 @@ import burp.api.montoya.core.ByteArray;
 
 import java.io.ByteArrayOutputStream;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -16,7 +15,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Deflate extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         Deflater deflater = new Deflater();
         deflater.setInput(input.getBytes());
 

--- a/src/main/java/de/usd/cstchef/operations/compression/GUnzip.java
+++ b/src/main/java/de/usd/cstchef/operations/compression/GUnzip.java
@@ -7,7 +7,6 @@ import burp.api.montoya.core.ByteArray;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -16,7 +15,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class GUnzip extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         ByteArrayInputStream in = new ByteArrayInputStream(input.getBytes());
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         GZIPInputStream gis = new GZIPInputStream(in);

--- a/src/main/java/de/usd/cstchef/operations/compression/Gzip.java
+++ b/src/main/java/de/usd/cstchef/operations/compression/Gzip.java
@@ -1,7 +1,5 @@
 package de.usd.cstchef.operations.compression;
 
-import java.util.zip.GZIPOutputStream;
-
 import javax.swing.JComboBox;
 
 import burp.api.montoya.core.ByteArray;
@@ -9,7 +7,6 @@ import burp.api.montoya.core.ByteArray;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -21,7 +18,7 @@ public class Gzip extends Operation {
     private JComboBox<Integer> compressionLevelBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         //GZIPOutputStream gzos = new GZIPOutputStream(out);
         GZIPOutputStreamWrapper gzos = new GZIPOutputStreamWrapper(out);

--- a/src/main/java/de/usd/cstchef/operations/compression/Inflate.java
+++ b/src/main/java/de/usd/cstchef/operations/compression/Inflate.java
@@ -6,7 +6,6 @@ import burp.api.montoya.core.ByteArray;
 
 import java.io.ByteArrayOutputStream;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -16,7 +15,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Inflate extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         Inflater inflater = new Inflater();
         inflater.setInput(input.getBytes());
 

--- a/src/main/java/de/usd/cstchef/operations/conditional/NumberCompare.java
+++ b/src/main/java/de/usd/cstchef/operations/conditional/NumberCompare.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.conditional;
 import javax.swing.JComboBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -13,7 +12,7 @@ public class NumberCompare extends ConditionalOperation {
     private JComboBox<String> operationBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         Double inputNumber;
         Double userNumber;

--- a/src/main/java/de/usd/cstchef/operations/conditional/RegexMatch.java
+++ b/src/main/java/de/usd/cstchef/operations/conditional/RegexMatch.java
@@ -6,7 +6,6 @@ import java.util.regex.Pattern;
 import javax.swing.JCheckBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -17,7 +16,7 @@ public class RegexMatch extends ConditionalOperation {
     private JCheckBox find;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         Pattern p = Pattern.compile(this.expr.getText());
         Matcher m = p.matcher(input.toString());

--- a/src/main/java/de/usd/cstchef/operations/conditional/StringContains.java
+++ b/src/main/java/de/usd/cstchef/operations/conditional/StringContains.java
@@ -2,11 +2,9 @@ package de.usd.cstchef.operations.conditional;
 
 import javax.swing.JCheckBox;
 
-import burp.BurpExtender;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -17,7 +15,7 @@ public class StringContains extends ConditionalOperation {
     private JCheckBox caseSensitive;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         MontoyaApi api = BurpUtils.getInstance().getApi();
         int start = api.utilities().byteUtils().indexOf(input.getBytes(), this.expr.getBytes().getBytes(), caseSensitive.isSelected(), 0, input.length());

--- a/src/main/java/de/usd/cstchef/operations/conditional/StringMatch.java
+++ b/src/main/java/de/usd/cstchef/operations/conditional/StringMatch.java
@@ -2,11 +2,9 @@ package de.usd.cstchef.operations.conditional;
 
 import javax.swing.JCheckBox;
 
-import burp.BurpExtender;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -17,7 +15,7 @@ public class StringMatch extends ConditionalOperation {
     private JCheckBox caseSensitive;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         
         ByteArray search = this.expr.getBytes();
         if( search.length() != input.length() ) {

--- a/src/main/java/de/usd/cstchef/operations/dataformat/FromBase64.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/FromBase64.java
@@ -2,7 +2,6 @@ package de.usd.cstchef.operations.dataformat;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Base64;
 
 import javax.swing.JCheckBox;
 
@@ -10,7 +9,6 @@ import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.utilities.Base64DecodingOptions;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -22,7 +20,7 @@ public class FromBase64 extends Operation implements ActionListener {
 	private JCheckBox urlSafeCheckBox;
 	
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) {
+    protected ByteArray perform(ByteArray input) {
 		MontoyaApi api = BurpUtils.getInstance().getApi();
 		if(!this.urlSafe) {
 			return api.utilities().base64Utils().decode(input);

--- a/src/main/java/de/usd/cstchef/operations/dataformat/FromHex.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/FromHex.java
@@ -5,10 +5,7 @@ import java.util.Set;
 import javax.swing.JComboBox;
 import org.bouncycastle.util.encoders.Hex;
 
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.dataformat.ToHex.Delimiter;
@@ -20,7 +17,7 @@ public class FromHex extends Operation {
     private JComboBox<String> delimiterBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String selectedKey = (String) this.delimiterBox.getSelectedItem();
         Delimiter delimiter = ToHex.delimiters.get(selectedKey);
 

--- a/src/main/java/de/usd/cstchef/operations/dataformat/HtmlDecode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/HtmlDecode.java
@@ -1,9 +1,6 @@
 package de.usd.cstchef.operations.dataformat;
 
-import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.text.StringEscapeUtils;
-
+import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
@@ -15,7 +12,7 @@ public class HtmlDecode extends Operation {
 
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
-        return factory.createByteArray(StringEscapeUtils.unescapeHtml4(input.toString()));
+        return factory.createByteArray(BurpUtils.getInstance().getApi().utilities().htmlUtils().decode(input.toString()));
     }
 
 }

--- a/src/main/java/de/usd/cstchef/operations/dataformat/HtmlDecode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/HtmlDecode.java
@@ -2,7 +2,6 @@ package de.usd.cstchef.operations.dataformat;
 
 import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -11,7 +10,7 @@ import de.usd.cstchef.operations.OperationCategory;
 public class HtmlDecode extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return factory.createByteArray(BurpUtils.getInstance().getApi().utilities().htmlUtils().decode(input.toString()));
     }
 

--- a/src/main/java/de/usd/cstchef/operations/dataformat/HtmlEncode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/HtmlEncode.java
@@ -5,7 +5,6 @@ import javax.swing.JCheckBox;
 import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.utilities.HtmlEncoding;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -16,7 +15,7 @@ public class HtmlEncode extends Operation {
     private JCheckBox checkbox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String encodedInput;
 

--- a/src/main/java/de/usd/cstchef/operations/dataformat/HtmlEncode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/HtmlEncode.java
@@ -1,12 +1,10 @@
 package de.usd.cstchef.operations.dataformat;
 
-import java.io.ByteArrayOutputStream;
-
 import javax.swing.JCheckBox;
 
-import org.apache.commons.text.StringEscapeUtils;
-
+import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.utilities.HtmlEncoding;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -20,31 +18,16 @@ public class HtmlEncode extends Operation {
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
 
-        ByteArray result = null;
-        if( checkbox.isSelected() ) {
+        String encodedInput;
 
-            ByteArray delimiter = factory.createByteArray("&#");
-            ByteArray closer = factory.createByteArray(";");
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-            out.write(delimiter.getBytes());
-            for (int i = 0; i < input.length() - 1; i++) {
-                out.write(String.valueOf(Byte.toUnsignedInt(input.getByte(i))).getBytes());
-                out.write(closer.getBytes());
-                out.write(delimiter.getBytes());
-            }
-
-            out.write(String.valueOf(Byte.toUnsignedInt(input.getByte(input.length() - 1))).getBytes());
-            out.write(closer.getBytes());
-            result = factory.createByteArray(out.toByteArray());
-
-        } else {
-            String tmp = input.toString();
-            tmp = StringEscapeUtils.escapeHtml4(tmp);
-            result = factory.createByteArray(tmp);
+        if(checkbox.isSelected()) {
+            encodedInput = BurpUtils.getInstance().getApi().utilities().htmlUtils().encode(input.toString(), HtmlEncoding.ALL_CHARACTERS);
+        }
+        else {
+            encodedInput = BurpUtils.getInstance().getApi().utilities().htmlUtils().encode(input.toString(), HtmlEncoding.STANDARD);
         }
 
-        return result;
+        return factory.createByteArray(encodedInput);
     }
 
     @Override

--- a/src/main/java/de/usd/cstchef/operations/dataformat/JsonBeautifier.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/JsonBeautifier.java
@@ -12,13 +12,23 @@ import de.usd.cstchef.operations.OperationCategory;
 public class JsonBeautifier extends Operation {
 	@Override
 	protected ByteArray perform(ByteArray input, Utils.MessageType messageType) throws Exception {
+
+		String beautifiedInput;
+
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
 			objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
 			JsonNode jsonNode = objectMapper.readTree(input.toString());
-			return factory.createByteArray(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode));
+			beautifiedInput = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
 		} catch (Exception e2) {
-			return input;
+			return factory.createByteArray("");
+		}
+
+		if(beautifiedInput.equals("null")) {
+			return factory.createByteArray("");
+		}
+		else {
+			return factory.createByteArray(beautifiedInput);
 		}
 	}
 }

--- a/src/main/java/de/usd/cstchef/operations/dataformat/JsonBeautifier.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/JsonBeautifier.java
@@ -4,14 +4,13 @@ import burp.api.montoya.core.ByteArray;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 
 @Operation.OperationInfos(name = "JSON Beautifier", category = OperationCategory.DATAFORMAT, description = "Format JSON Data.")
 public class JsonBeautifier extends Operation {
 	@Override
-	protected ByteArray perform(ByteArray input, Utils.MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 
 		String beautifiedInput;
 

--- a/src/main/java/de/usd/cstchef/operations/dataformat/ToBase64.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/ToBase64.java
@@ -2,19 +2,13 @@ package de.usd.cstchef.operations.dataformat;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Base64;
 
-import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
 
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.utilities.Base64DecodingOptions;
 import burp.api.montoya.utilities.Base64EncodingOptions;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -26,7 +20,7 @@ public class ToBase64 extends Operation implements ActionListener {
 	private JCheckBox urlSafeCheckBox;
 	
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) {
+    protected ByteArray perform(ByteArray input) {
     	MontoyaApi api = BurpUtils.getInstance().getApi();
 		if(!this.urlSafe) {
 			return api.utilities().base64Utils().encode(input);

--- a/src/main/java/de/usd/cstchef/operations/dataformat/ToHex.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/ToHex.java
@@ -8,7 +8,6 @@ import javax.swing.JComboBox;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -34,7 +33,7 @@ public class ToHex extends Operation {
     private JComboBox<String> delimiterBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String selectedKey = (String) this.delimiterBox.getSelectedItem();
         Delimiter delimiter = ToHex.delimiters.get(selectedKey);
 

--- a/src/main/java/de/usd/cstchef/operations/dataformat/UrlDecode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/UrlDecode.java
@@ -1,10 +1,8 @@
 package de.usd.cstchef.operations.dataformat;
 
-import burp.BurpExtender;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -13,7 +11,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class UrlDecode extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         MontoyaApi api = BurpUtils.getInstance().getApi();
 
         ByteArray result = api.utilities().urlUtils().decode(input);

--- a/src/main/java/de/usd/cstchef/operations/dataformat/UrlEncode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/UrlEncode.java
@@ -21,6 +21,10 @@ public class UrlEncode extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        if(input.length() == 0) {
+            return input;
+        }
+
         ByteArray result = null;
         MontoyaApi api = BurpUtils.getInstance().getApi();
         if( checkbox.isSelected() ) {

--- a/src/main/java/de/usd/cstchef/operations/dataformat/UrlEncode.java
+++ b/src/main/java/de/usd/cstchef/operations/dataformat/UrlEncode.java
@@ -6,11 +6,9 @@ import javax.swing.JCheckBox;
 
 import org.bouncycastle.util.encoders.Hex;
 
-import burp.BurpExtender;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -21,7 +19,7 @@ public class UrlEncode extends Operation {
     private JCheckBox checkbox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         ByteArray result = null;
         MontoyaApi api = BurpUtils.getInstance().getApi();

--- a/src/main/java/de/usd/cstchef/operations/datetime/DateTime.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/DateTime.java
@@ -4,7 +4,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -16,7 +15,7 @@ public class DateTime extends Operation {
     private VariableTextField patternTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String pattern = this.patternTxt.getText().trim();
         SimpleDateFormat format = new SimpleDateFormat(pattern);
         return factory.createByteArray(format.format(new Date()));

--- a/src/main/java/de/usd/cstchef/operations/datetime/DateTime.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/DateTime.java
@@ -10,7 +10,7 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Date Time", category = OperationCategory.DATES, description = "Returnes the current date time formatted with the provided date time pattern.")
+@OperationInfos(name = "Date Time", category = OperationCategory.DATES, description = "Returns the current date time formatted with the provided date time pattern.")
 public class DateTime extends Operation {
 
     private VariableTextField patternTxt;

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
@@ -15,7 +15,7 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Unix/Epoch Timestamp Offset", category = OperationCategory.DATES, description = "Returns a Epoch timestamp shifted into future or past.")
+@OperationInfos(name = "Unix/Epoch Timestamp Offset", category = OperationCategory.DATES, description = "Returns Unix/Epoch timestamp shifted into future or past.")
 public class TimestampOffset extends Operation {
 
     private VariableTextField offsetTxt;

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
@@ -1,15 +1,9 @@
 package de.usd.cstchef.operations.datetime;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 
-import org.bouncycastle.jcajce.provider.asymmetric.dsa.DSASigner.stdDSA;
-
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -24,7 +18,7 @@ public class TimestampOffset extends Operation {
     private JCheckBox milliseconds;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
 		if(offsetTxt.getText().isEmpty()) return input;
         

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampOffset.java
@@ -15,7 +15,7 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Unix/Epoch Timestamp Offset", category = OperationCategory.DATES, description = "Returns Unix/Epoch timestamp shifted into future or past.")
+@OperationInfos(name = "Unix/Epoch time with offset", category = OperationCategory.DATES, description = "Returns the current Unix/Epoch time shifted into the past or future.")
 public class TimestampOffset extends Operation {
 
     private VariableTextField offsetTxt;
@@ -24,12 +24,21 @@ public class TimestampOffset extends Operation {
     private JCheckBox milliseconds;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {        
+    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+
+		if(offsetTxt.getText().isEmpty()) return input;
         
         String interval = (String)this.interval.getSelectedItem();
         TimeOffsets intervalEnum = TimeOffsets.getEnumObj(interval);
-        int offset = Integer.parseInt(offsetTxt.getText());
         boolean milliseconds = this.milliseconds.isSelected();
+		int offset = 0;
+
+		try {
+			offset = Integer.parseInt(offsetTxt.getText());
+		}
+		catch(Exception e) {
+			throw new IllegalArgumentException("Please provide an integer as offset.");
+		}
              
         
     	long calculatedOffset = this.getOffset(intervalEnum, offset, milliseconds);

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
@@ -14,7 +14,7 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Epoch to DateTime", category = OperationCategory.DATES, description = "Returns a given Unix (Epoch) timestamp formatted with the provided date time pattern.")
+@OperationInfos(name = "Unix/Epoch to DateTime", category = OperationCategory.DATES, description = "Returns a given Unix/Epoch timestamp formatted with the provided date time pattern.")
 public class TimestampToDateTime extends Operation {
 
     private VariableTextField patternTxt;    

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
@@ -6,9 +6,7 @@ import java.util.Date;
 
 import javax.swing.JCheckBox;
 
-import burp.Logger;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -22,7 +20,7 @@ public class TimestampToDateTime extends Operation {
     
     
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         if(input.toString().isEmpty()) return factory.createByteArray("");
         String pattern = this.patternTxt.getText().trim();

--- a/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/TimestampToDateTime.java
@@ -14,7 +14,7 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Unix/Epoch to DateTime", category = OperationCategory.DATES, description = "Returns a given Unix/Epoch timestamp formatted with the provided date time pattern.")
+@OperationInfos(name = "Unix/Epoch to DateTime", category = OperationCategory.DATES, description = "Returns the Unix/Epoch input in the specified date and time format.")
 public class TimestampToDateTime extends Operation {
 
     private VariableTextField patternTxt;    
@@ -23,6 +23,8 @@ public class TimestampToDateTime extends Operation {
     
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+
+        if(input.toString().isEmpty()) return factory.createByteArray("");
         String pattern = this.patternTxt.getText().trim();
         SimpleDateFormat format = new SimpleDateFormat(pattern);
         

--- a/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
@@ -8,7 +8,7 @@ import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
-@OperationInfos(name = "Unix/Epoch Timestamp", category = OperationCategory.DATES, description = "Returnes the current unix/epoch timestamp.")
+@OperationInfos(name = "Unix/Epoch Timestamp", category = OperationCategory.DATES, description = "Returns the current Unix/Epoch timestamp.")
 public class UnixTimestamp extends Operation {
 
     private JCheckBox milliBox;

--- a/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.datetime;
 import javax.swing.JCheckBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -14,7 +13,7 @@ public class UnixTimestamp extends Operation {
     private JCheckBox milliBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         long timestamp = 0;
         if (milliBox.isSelected()) {
             timestamp = System.currentTimeMillis();

--- a/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
+++ b/src/main/java/de/usd/cstchef/operations/datetime/UnixTimestamp.java
@@ -8,7 +8,7 @@ import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
-@OperationInfos(name = "Unix/Epoch Timestamp", category = OperationCategory.DATES, description = "Returns the current Unix/Epoch timestamp.")
+@OperationInfos(name = "Unix/Epoch time", category = OperationCategory.DATES, description = "Returns the current Unix/Epoch time.")
 public class UnixTimestamp extends Operation {
 
     private JCheckBox milliBox;

--- a/src/main/java/de/usd/cstchef/operations/encryption/CryptOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/CryptOperation.java
@@ -94,7 +94,20 @@ public abstract class CryptOperation extends Operation {
         this.cipherMode = new JComboBox<>(info.getModes());
         this.addUIElement("Mode", this.cipherMode);
 
-        this.paddings = new JComboBox<>(info.getPaddings());
+        /*
+         * javax.crypto.Cipher uses PKCS7 internally but names it PKCS5.
+         * The only difference between the two padding mechanisms is the
+         * block size they're working with and to not confuse the user
+         * we name the combobox item accordingly (see GitHub Issue #166)
+         */
+        String[] paddings = info.getPaddings();
+        for(int i = 0; i < paddings.length; i++) {
+            if(paddings[i].equals("PKCS5PADDING")) {
+                paddings[i] = "PKCS5PADDING / PKCS7PADDING";
+            }
+        }
+
+        this.paddings = new JComboBox<>(paddings);
         this.addUIElement("Padding", this.paddings);
 
         this.inputMode = new JComboBox<>(inOutModes);

--- a/src/main/java/de/usd/cstchef/operations/encryption/DecryptionOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/DecryptionOperation.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.encryption;
 import javax.crypto.Cipher;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 
 public abstract class DecryptionOperation extends CryptOperation {
 
@@ -12,7 +11,7 @@ public abstract class DecryptionOperation extends CryptOperation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         /*
          * javax.crypto.Cipher uses PKCS7 internally but names it PKCS5.

--- a/src/main/java/de/usd/cstchef/operations/encryption/DecryptionOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/DecryptionOperation.java
@@ -13,8 +13,20 @@ public abstract class DecryptionOperation extends CryptOperation {
 
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+
+        /*
+         * javax.crypto.Cipher uses PKCS7 internally but names it PKCS5.
+         * The only difference between the two padding mechanisms is the
+         * block size they're working with and to not confuse the user
+         * we name the combobox item accordingly (see GitHub Issue #166)
+         */
+        String padding = (String) this.paddings.getSelectedItem();
+        if(padding.equals("PKCS5PADDING / PKCS7PADDING")) {
+            padding = "PKCS5PADDING";
+        }
+
         return factory.createByteArray(this.crypt(input.getBytes(), Cipher.DECRYPT_MODE, this.algorithm, (String) this.cipherMode.getSelectedItem(),
-                (String) this.paddings.getSelectedItem()));
+                padding));
     }
 
 }

--- a/src/main/java/de/usd/cstchef/operations/encryption/EncryptionOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/EncryptionOperation.java
@@ -13,8 +13,20 @@ public abstract class EncryptionOperation extends CryptOperation {
 
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+
+        /*
+         * javax.crypto.Cipher uses PKCS7 internally but names it PKCS5.
+         * The only difference between the two padding mechanisms is the
+         * block size they're working with and to not confuse the user
+         * we name the combobox item accordingly (see GitHub Issue #166)
+         */
+        String padding = (String) this.paddings.getSelectedItem();
+        if(padding.equals("PKCS5PADDING / PKCS7PADDING")) {
+            padding = "PKCS5PADDING";
+        }
+
         return factory.createByteArray(this.crypt(input.getBytes(), Cipher.ENCRYPT_MODE, this.algorithm, (String) this.cipherMode.getSelectedItem(),
-                (String) this.paddings.getSelectedItem()));
+                padding));
     }
 
 }

--- a/src/main/java/de/usd/cstchef/operations/encryption/EncryptionOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/EncryptionOperation.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.encryption;
 import javax.crypto.Cipher;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 
 public abstract class EncryptionOperation extends CryptOperation {
 
@@ -12,7 +11,7 @@ public abstract class EncryptionOperation extends CryptOperation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         /*
          * javax.crypto.Cipher uses PKCS7 internally but names it PKCS5.

--- a/src/main/java/de/usd/cstchef/operations/encryption/RsaDecryption.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/RsaDecryption.java
@@ -8,7 +8,6 @@ import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.encryption.CipherUtils.CipherInfo;
 import de.usd.cstchef.operations.signature.KeystoreOperation;
@@ -30,7 +29,7 @@ public class RsaDecryption extends KeystoreOperation {
         this.createMyUI();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         if( ! this.keyAvailable.isSelected() )
             throw new IllegalArgumentException("No private key available.");

--- a/src/main/java/de/usd/cstchef/operations/encryption/RsaEncryption.java
+++ b/src/main/java/de/usd/cstchef/operations/encryption/RsaEncryption.java
@@ -8,7 +8,6 @@ import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.encryption.CipherUtils.CipherInfo;
 import de.usd.cstchef.operations.signature.KeystoreOperation;
@@ -30,7 +29,7 @@ public class RsaEncryption extends KeystoreOperation {
         this.createMyUI();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         if( ! this.certAvailable.isSelected() )
             throw new IllegalArgumentException("No certificate available.");

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
@@ -10,9 +10,10 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class HttpBodyExtractor extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
-        parseMessageType(input);
+        MessageType messageType = parseMessageType(input);
+
         if(messageType == MessageType.REQUEST){
 
             ByteArray result = factory.getHttpRequestBody(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
@@ -1,11 +1,6 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.Arrays;
-
-import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
@@ -16,11 +11,29 @@ public class HttpBodyExtractor extends Operation {
 
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+
+        parseMessageType(input);
         if(messageType == MessageType.REQUEST){
-            return factory.getHttpRequestBody(input);
+
+            ByteArray result = factory.getHttpRequestBody(input);
+
+            if(result.length() == 0) {
+                throw new IllegalArgumentException("HTTP Request has no body.");
+            }
+            else {
+                return result;
+            }
         }
         else if(messageType == MessageType.RESPONSE){
-            return factory.getHttpResponseBody(input);
+
+            ByteArray result = factory.getHttpResponseBody(input);
+
+            if(result.length() == 0) {
+                throw new IllegalArgumentException("HTTP Response has no body.");
+            }
+            else {
+                return result;
+            }
         }
         else{
             return parseRawMessage(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpBodyExtractor.java
@@ -19,7 +19,7 @@ public class HttpBodyExtractor extends Operation {
             ByteArray result = factory.getHttpRequestBody(input);
 
             if(result.length() == 0) {
-                throw new IllegalArgumentException("HTTP Request has no body.");
+                throw new IllegalArgumentException("HTTP request has no body.");
             }
             else {
                 return result;
@@ -30,7 +30,7 @@ public class HttpBodyExtractor extends Operation {
             ByteArray result = factory.getHttpResponseBody(input);
 
             if(result.length() == 0) {
-                throw new IllegalArgumentException("HTTP Response has no body.");
+                throw new IllegalArgumentException("HTTP response has no body.");
             }
             else {
                 return result;

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpCookieExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpCookieExtractor.java
@@ -1,20 +1,7 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.List;
-
-import org.bouncycastle.util.Arrays;
-
-import burp.BurpExtender;
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.Cookie;
-import burp.api.montoya.http.message.HttpHeader;
 import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
-import burp.objects.CstcByteArray;
-import burp.objects.CstcHttpRequest;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -27,11 +14,13 @@ public class HttpCookieExtractor extends Operation {
     protected VariableTextField cookieNameField;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String cookieName = cookieNameField.getText();
 
         if(input.toString().isEmpty() || cookieName.isEmpty()) return factory.createByteArray("");
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST) {
             HttpRequest request = factory.createHttpRequest(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpCookieExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpCookieExtractor.java
@@ -16,11 +16,13 @@ public class HttpCookieExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String cookieName = cookieNameField.getText();
 
-        if(input.toString().isEmpty() || cookieName.isEmpty()) return factory.createByteArray("");
-
-        MessageType messageType = parseMessageType(input);
+        if(cookieName.isEmpty()) {
+            return input;
+        }
 
         if(messageType == MessageType.REQUEST) {
             HttpRequest request = factory.createHttpRequest(input);
@@ -40,18 +42,18 @@ public class HttpCookieExtractor extends Operation {
                     }
                 }
                 else {
-                    throw new IllegalArgumentException("Parameter name not found.");
+                    throw new IllegalArgumentException("Cookie not found.");
                 }
             }
 
-            throw new IllegalArgumentException("Parameter name not found.");
+            throw new IllegalArgumentException("Cookie not found.");
            
         }
         else if(messageType == MessageType.RESPONSE) {
             String cookie = factory.createHttpResponse(input).cookieValue(cookieName);
             
             if(cookie == null) {
-                throw new IllegalArgumentException("Parameter name not found.");
+                throw new IllegalArgumentException("Cookie not found.");
             }
             else {
                 return factory.createByteArray(cookie);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpGetExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpGetExtractor.java
@@ -16,19 +16,27 @@ public class HttpGetExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String parameterName = parameter.getText();
-        if (parameterName.equals(""))
-            return factory.createByteArray(0);
-
         MessageType messageType = parseMessageType(input);
 
-        if (messageType == MessageType.REQUEST) {
-            return factory.createByteArray(factory.createHttpRequest(input).parameterValue(parameterName, HttpParameterType.URL));
-        } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
-        } else {
-            return parseRawMessage(input);
+        if(messageType == MessageType.RESPONSE) {
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
         }
+
+        String parameterName = parameter.getText();
+        if (parameterName.equals("")) {
+            return input;
+        }
+
+        if (messageType == MessageType.REQUEST) {
+            try {
+                return factory.createByteArray(checkNull(factory.createHttpRequest(input).parameterValue(parameterName, HttpParameterType.URL)));
+            }
+            catch(Exception e) {
+                throw new IllegalArgumentException("GET parameter not found.");
+            }
+        }
+
+        return input;
 
     }
 

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpGetExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpGetExtractor.java
@@ -1,19 +1,7 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.Arrays;
-
-import burp.BurpExtender;
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.Cookie;
-import burp.api.montoya.http.message.params.HttpParameter;
 import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.params.ParsedHttpParameter;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
-import burp.api.montoya.ui.editor.HttpRequestEditor;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -26,11 +14,13 @@ public class HttpGetExtractor extends Operation {
     protected VariableTextField parameter;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = parameter.getText();
         if (parameterName.equals(""))
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             return factory.createByteArray(factory.createHttpRequest(input).parameterValue(parameterName, HttpParameterType.URL));

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractor.java
@@ -1,8 +1,6 @@
 package de.usd.cstchef.operations.extractors;
 
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,11 +13,14 @@ public class HttpHeaderExtractor extends Operation {
     protected VariableTextField headerNameField;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String headerName = headerNameField.getText();
         if( headerName.length() == 0 )
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
+
         if(messageType == MessageType.REQUEST){
             return factory.createByteArray(checkNull(factory.createHttpRequest(input).headerValue(headerName)));
         }

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractor.java
@@ -15,17 +15,28 @@ public class HttpHeaderExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String headerName = headerNameField.getText();
-        if( headerName.length() == 0 )
-            return factory.createByteArray(0);
-
         MessageType messageType = parseMessageType(input);
 
+        String headerName = headerNameField.getText();
+        if( headerName.length() == 0 ) {
+            return input;
+        }
+
         if(messageType == MessageType.REQUEST){
-            return factory.createByteArray(checkNull(factory.createHttpRequest(input).headerValue(headerName)));
+            try {
+                return factory.createByteArray(checkNull(factory.createHttpRequest(input).headerValue(headerName)));
+            }
+            catch(Exception e) {
+                throw new IllegalArgumentException("Header not found.");
+            }
         }
         else if(messageType == MessageType.RESPONSE){
-            return factory.createByteArray(checkNull(factory.createHttpResponse(input).headerValue(headerName)));
+            try {
+                return factory.createByteArray(checkNull(factory.createHttpResponse(input).headerValue(headerName)));
+            }
+            catch(Exception e) {
+                throw new IllegalArgumentException("Header not found.");
+            }
         }
         else{
             return parseRawMessage(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpJsonExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpJsonExtractor.java
@@ -16,11 +16,11 @@ public class HttpJsonExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String keyName = fieldTxt.getText();
         if( keyName.equals("") )
-            return factory.createByteArray(0);
-
-        MessageType messageType = parseMessageType(input);
+            return input;
 
         JsonExtractor extractor = new JsonExtractor(keyName);
         if(messageType == MessageType.REQUEST){

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpJsonExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpJsonExtractor.java
@@ -3,9 +3,6 @@ package de.usd.cstchef.operations.extractors;
 import javax.swing.JTextField;
 
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -17,19 +14,20 @@ public class HttpJsonExtractor extends Operation {
     protected JTextField fieldTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String keyName = fieldTxt.getText();
         if( keyName.equals("") )
-            //return ByteArray.byteArray(0);
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
 
         JsonExtractor extractor = new JsonExtractor(keyName);
         if(messageType == MessageType.REQUEST){
-            return checkNull(extractor.perform(factory.createHttpRequest(input).body(), messageType));
+            return checkNull(extractor.perform(factory.createHttpRequest(input).body()));
         }
         else if(messageType == MessageType.RESPONSE){
-            return checkNull(extractor.perform(factory.createHttpResponse(input).body(), messageType));
+            return checkNull(extractor.perform(factory.createHttpResponse(input).body()));
         }
         else{
             return parseRawMessage(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpMethodExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpMethodExtractor.java
@@ -21,11 +21,11 @@ public class HttpMethodExtractor extends Operation {
                 return factory.createByteArray(factory.createHttpRequest(input).method());
             }
             catch(Exception e){
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Input is not a valid HTTP request.");
             }
         }
         else if(messageType == MessageType.RESPONSE){
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
         }
         else{
             return parseRawMessage(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpMethodExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpMethodExtractor.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.extractors;
 
 
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.requests.HttpRequest;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -13,7 +12,10 @@ import de.usd.cstchef.operations.OperationCategory;
 public class HttpMethodExtractor extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
+
+        MessageType messageType = parseMessageType(input);
+
         if(messageType == MessageType.REQUEST){
             try{
                 return factory.createByteArray(factory.createHttpRequest(input).method());

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractor.java
@@ -2,7 +2,6 @@ package de.usd.cstchef.operations.extractors;
 
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.requests.HttpRequest;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,11 +14,13 @@ public class HttpMultipartExtractor extends Operation {
     protected VariableTextField parameter;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = parameter.getText();
         if (parameterName.equals(""))
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try{

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractor.java
@@ -16,21 +16,21 @@ public class HttpMultipartExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String parameterName = parameter.getText();
         if (parameterName.equals(""))
-            return factory.createByteArray(0);
-
-        MessageType messageType = parseMessageType(input);
+            return input;
 
         if (messageType == MessageType.REQUEST) {
             try{
                 return factory.createByteArray(checkNull(factory.createHttpRequest(input).parameterValue(parameterName, HttpParameterType.BODY)));
             }
             catch(Exception e){
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Parameter name not found.");
             }
         } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
         } else {
             return parseRawMessage(input);
         }

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpPostExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpPostExtractor.java
@@ -1,13 +1,7 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.Arrays;
-
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.params.ParsedHttpParameter;
-import burp.api.montoya.http.message.requests.HttpRequest;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -20,11 +14,13 @@ public class HttpPostExtractor extends Operation {
     protected VariableTextField parameter;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = parameter.getText();
         if (parameterName.equals(""))
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpPostExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpPostExtractor.java
@@ -16,20 +16,20 @@ public class HttpPostExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String parameterName = parameter.getText();
         if (parameterName.equals(""))
-            return factory.createByteArray(0);
-
-        MessageType messageType = parseMessageType(input);
+            return input;
 
         if (messageType == MessageType.REQUEST) {
             try {
                 return checkNull(factory.createByteArray(factory.createHttpRequest(input).parameterValue(parameterName, HttpParameterType.BODY)));
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("POST parameter not found.");
             }
         } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
         } else {
             return parseRawMessage(input);
         }

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpUriExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpUriExtractor.java
@@ -34,10 +34,10 @@ public class HttpUriExtractor extends Operation {
                     return factory.createByteArray(url);
                 }
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Input is not a valid request.");
             }
         } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
         } else {
             return parseRawMessage(input);
         }

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpUriExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpUriExtractor.java
@@ -1,16 +1,8 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.Arrays;
-import java.util.List;
-
 import javax.swing.JCheckBox;
 
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.params.ParsedHttpParameter;
-import burp.api.montoya.http.message.requests.HttpRequest;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -29,7 +21,9 @@ public class HttpUriExtractor extends Operation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpXmlExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpXmlExtractor.java
@@ -16,7 +16,7 @@ import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
-@OperationInfos(name = "Get HTTP XML", category = OperationCategory.EXTRACTORS, description = "Extract the first occurrence of a XML value from HTTP message.")
+@OperationInfos(name = "Get HTTP XML", category = OperationCategory.EXTRACTORS, description = "Extracts XML of the HTTP message.")
 public class HttpXmlExtractor extends Operation {
 
     protected JTextField fieldTxt;
@@ -24,17 +24,17 @@ public class HttpXmlExtractor extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String keyName = fieldTxt.getText();
         if (keyName.equals(""))
-            return factory.createByteArray(0);
-
-        MessageType messageType = parseMessageType(input);
+            return input;
 
         if (messageType == MessageType.REQUEST) {
             try {
                 return factory.createByteArray(checkNull(factory.createHttpRequest(input).parameterValue(keyName, HttpParameterType.XML)));
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("XML element not found.");
             }
         } else if (messageType == MessageType.RESPONSE) {
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -44,7 +44,7 @@ public class HttpXmlExtractor extends Operation {
             try {
                 return factory.createByteArray(checkNull(nodeList.item(0).getTextContent()));
             } catch (NullPointerException e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("XML element not found.");
             }
         } else {
             return parseRawMessage(input);

--- a/src/main/java/de/usd/cstchef/operations/extractors/HttpXmlExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/HttpXmlExtractor.java
@@ -1,9 +1,6 @@
 package de.usd.cstchef.operations.extractors;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.io.InputStream;
 
 import javax.swing.JTextField;
 import javax.xml.parsers.DocumentBuilder;
@@ -14,8 +11,6 @@ import org.w3c.dom.NodeList;
 
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -27,11 +22,13 @@ public class HttpXmlExtractor extends Operation {
     protected JTextField fieldTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String keyName = fieldTxt.getText();
         if (keyName.equals(""))
             return factory.createByteArray(0);
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/extractors/JsonExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/JsonExtractor.java
@@ -1,7 +1,5 @@
 package de.usd.cstchef.operations.extractors;
 
-import java.util.LinkedHashMap;
-
 import javax.swing.JTextField;
 
 import com.jayway.jsonpath.Configuration;
@@ -9,7 +7,6 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -35,7 +32,7 @@ public class JsonExtractor extends Operation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         if( fieldTxt.getText().equals("") )
             return factory.createByteArray(0);

--- a/src/main/java/de/usd/cstchef/operations/extractors/JsonExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/JsonExtractor.java
@@ -35,7 +35,7 @@ public class JsonExtractor extends Operation {
     protected ByteArray perform(ByteArray input) throws Exception {
 
         if( fieldTxt.getText().equals("") )
-            return factory.createByteArray(0);
+            return input;
 
         Object document = provider.parse(input.toString());
         Object result = JsonPath.read(document, fieldTxt.getText());

--- a/src/main/java/de/usd/cstchef/operations/extractors/LineExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/LineExtractor.java
@@ -2,12 +2,9 @@ package de.usd.cstchef.operations.extractors;
 
 import javax.swing.JComboBox;
 
-import org.bouncycastle.util.Arrays;
-
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -20,7 +17,7 @@ public class LineExtractor extends Operation {
     protected JComboBox<String> formatBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         int lineNumber = 0;
         try {

--- a/src/main/java/de/usd/cstchef/operations/extractors/RegexExtractor.java
+++ b/src/main/java/de/usd/cstchef/operations/extractors/RegexExtractor.java
@@ -6,7 +6,6 @@ import java.util.regex.Pattern;
 import javax.swing.JComboBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -22,7 +21,7 @@ public class RegexExtractor extends Operation {
     protected JComboBox<String> outputBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         Pattern p = Pattern.compile(this.regexTxt.getText());
         Matcher m = p.matcher(input.toString());
         String outputType = (String) this.outputBox.getSelectedItem();

--- a/src/main/java/de/usd/cstchef/operations/hashing/HashOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/hashing/HashOperation.java
@@ -8,7 +8,6 @@ import javax.swing.JComboBox;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 
 public abstract class HashOperation extends Operation {
@@ -28,7 +27,7 @@ public abstract class HashOperation extends Operation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return factory.createByteArray(this.hash(input.getBytes()));
     }
 

--- a/src/main/java/de/usd/cstchef/operations/hashing/Hmac.java
+++ b/src/main/java/de/usd/cstchef/operations/hashing/Hmac.java
@@ -6,7 +6,6 @@ import javax.swing.JComboBox;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -19,7 +18,7 @@ public class Hmac extends Operation {
     private JComboBox<String> hashAlgoBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         byte[] key = this.keyTxt.getText().getBytes();
         String algo = "Hmac" + (String) hashAlgoBox.getSelectedItem();
         SecretKeySpec signingKey = new SecretKeySpec(key, algo);

--- a/src/main/java/de/usd/cstchef/operations/hashing/Luhn.java
+++ b/src/main/java/de/usd/cstchef/operations/hashing/Luhn.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.hashing;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -11,7 +10,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Luhn extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String exceptionMessage = "Luhn can only be applied to numerical values.";
         if(input.length() == 0) throw new IllegalArgumentException(exceptionMessage);

--- a/src/main/java/de/usd/cstchef/operations/hashing/Luhn.java
+++ b/src/main/java/de/usd/cstchef/operations/hashing/Luhn.java
@@ -13,9 +13,12 @@ public class Luhn extends Operation {
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
 
+        String exceptionMessage = "Luhn can only be applied to numerical values.";
+        if(input.length() == 0) throw new IllegalArgumentException(exceptionMessage);
+
         for (int i = 0; i < input.length(); i++){
             if ((input.getByte(i) < '0') || (input.getByte(i) > '9')) {
-                throw new IllegalArgumentException("Luhn can only be applied to numerical values.");
+                throw new IllegalArgumentException(exceptionMessage);
             }
         }
 

--- a/src/main/java/de/usd/cstchef/operations/misc/ReadFile.java
+++ b/src/main/java/de/usd/cstchef/operations/misc/ReadFile.java
@@ -8,7 +8,6 @@ import javax.swing.JButton;
 import javax.swing.JFileChooser;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -21,7 +20,7 @@ public class ReadFile extends Operation implements ActionListener {
     private VariableTextField fileNameTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String path = fileNameTxt.getText();
 
         File file = new File(path);

--- a/src/main/java/de/usd/cstchef/operations/misc/RequestBuilder.java
+++ b/src/main/java/de/usd/cstchef/operations/misc/RequestBuilder.java
@@ -1,5 +1,7 @@
 package de.usd.cstchef.operations.misc;
 
+import javax.swing.JComboBox;
+
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
@@ -7,22 +9,26 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "GET Request Builder", category = OperationCategory.MISC, description = "Build a basic GET request.")
-public class GetRequestBuilder extends Operation {
+@OperationInfos(name = "Request Builder", category = OperationCategory.MISC, description = "Build a basic request to use in Send Plain Request.")
+public class RequestBuilder extends Operation {
 
     private VariableTextField host;
     private VariableTextField document;
     private VariableTextField accept;
+    private JComboBox<String> requestMethodBox;
 
     @Override
     protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
-        return factory.createByteArray(String.format("GET %s HTTP/1.1\n" + //
-                "Host: %s\n" + //
-                "Accept: %s", document.getText(), host.getText(), accept.getText()));
+        return factory.createByteArray(String.format("%s %s HTTP/1.1\r\n" + //
+                "Host: %s\r\n" + //
+                "Accept: %s\r\n\r\n", requestMethodBox.getSelectedItem(), document.getText(), host.getText(), accept.getText()));
     }
 
     @Override
     public void createUI() {
+        this.requestMethodBox = new JComboBox<>(new String[] {"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"});
+        this.addUIElement("Method", this.requestMethodBox);
+
         this.document = new VariableTextField();
         this.addUIElement("Document", this.document);
 

--- a/src/main/java/de/usd/cstchef/operations/misc/RequestBuilder.java
+++ b/src/main/java/de/usd/cstchef/operations/misc/RequestBuilder.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.misc;
 import javax.swing.JComboBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -18,7 +17,7 @@ public class RequestBuilder extends Operation {
     private JComboBox<String> requestMethodBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return factory.createByteArray(String.format("%s %s HTTP/1.1\r\n" + //
                 "Host: %s\r\n" + //
                 "Accept: %s\r\n\r\n", requestMethodBox.getSelectedItem(), document.getText(), host.getText(), accept.getText()));

--- a/src/main/java/de/usd/cstchef/operations/misc/WriteFile.java
+++ b/src/main/java/de/usd/cstchef/operations/misc/WriteFile.java
@@ -11,7 +11,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -27,7 +26,7 @@ public class WriteFile extends Operation implements ActionListener {
     private FileOutputStream out;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String path = fileNameTxt.getText();
 
         if (!path.isEmpty()) {

--- a/src/main/java/de/usd/cstchef/operations/misc/WriteFile.java
+++ b/src/main/java/de/usd/cstchef/operations/misc/WriteFile.java
@@ -16,13 +16,13 @@ import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-@OperationInfos(name = "Write File", category = OperationCategory.MISC, description = "Appends data to the end of a file.")
+@OperationInfos(name = "Write File", category = OperationCategory.MISC, description = "Write data to a file.")
 public class WriteFile extends Operation implements ActionListener {
 
     private final JFileChooser fileChooser = new JFileChooser();
     private VariableTextField fileNameTxt;
     private JCheckBox overwriteCheckbox;
-    private String lastPath = "";
+    private JCheckBox newLineCheckBox;
     private FileOutputStream out;
 
     @Override
@@ -32,7 +32,9 @@ public class WriteFile extends Operation implements ActionListener {
         if (!path.isEmpty()) {
             out = new FileOutputStream(path, this.overwriteCheckbox.isSelected());
             out.write(input.getBytes());
-            out.write('\n');
+            if(this.newLineCheckBox.isSelected()) {
+                out.write('\n');   
+            }
             out.close();
         }
         return input;
@@ -47,9 +49,13 @@ public class WriteFile extends Operation implements ActionListener {
         chooseFileButton.addActionListener(this);
         this.addUIElement(null, chooseFileButton, false, "button1");
 
-        this.overwriteCheckbox = new JCheckBox("Append Contents");
+        this.overwriteCheckbox = new JCheckBox("Append");
         this.overwriteCheckbox.setSelected(true);
-        this.addUIElement("Append Contents", overwriteCheckbox);
+        this.addUIElement(null, overwriteCheckbox, "checkbox1");
+
+        this.newLineCheckBox = new JCheckBox("Add new line");
+        this.newLineCheckBox.setSelected(false);
+        this.addUIElement(null, newLineCheckBox, "checkbox2");
     }
 
 

--- a/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
+++ b/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
@@ -16,7 +16,10 @@ import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
+import de.usd.cstchef.view.filter.FilterState.BurpOperation;
 import de.usd.cstchef.view.ui.VariableTextField;
+
+import static burp.api.montoya.core.ToolType.EXTENSIONS;
 
 @OperationInfos(name = "Send Plain Request", category = OperationCategory.NETWORKING, description = "Makes an request and returns the response. You can use this operation in combination with e.g. \"Static String\" to perform more complex requests.")
 public class PlainRequest extends Operation {
@@ -63,6 +66,11 @@ public class PlainRequest extends Operation {
 
         @Override
         public HttpRequestResponse call() throws Exception {
+            if(BurpUtils.getInstance().getFilterState().shouldProcess(BurpOperation.OUTGOING, EXTENSIONS)) {
+                HttpRequest requestWithCustomHeader = HttpRequest.httpRequest(service, data).withAddedHeader("X-CSTC-79301f837932346cb067c568e27369bf", "cstc");
+                return api.http().sendRequest(requestWithCustomHeader);
+            }
+
             return api.http().sendRequest(HttpRequest.httpRequest(service, data));
         }
 

--- a/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
+++ b/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
@@ -12,7 +12,6 @@ import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.HttpService;
 import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.requests.HttpRequest;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -29,7 +28,7 @@ public class PlainRequest extends Operation {
     private JCheckBox sslEnabledBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         MontoyaApi api = BurpUtils.getInstance().getApi();
         HttpService service = HttpService.httpService(hostTxt.getText(), Integer.valueOf(portTxt.getText()), sslEnabledBox.isSelected());
 

--- a/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
+++ b/src/main/java/de/usd/cstchef/operations/networking/PlainRequest.java
@@ -15,10 +15,8 @@ import burp.api.montoya.http.message.requests.HttpRequest;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
-import de.usd.cstchef.view.filter.FilterState.BurpOperation;
 import de.usd.cstchef.view.ui.VariableTextField;
 
-import static burp.api.montoya.core.ToolType.EXTENSIONS;
 
 @OperationInfos(name = "Send Plain Request", category = OperationCategory.NETWORKING, description = "Makes an request and returns the response. You can use this operation in combination with e.g. \"Static String\" to perform more complex requests.")
 public class PlainRequest extends Operation {
@@ -65,12 +63,8 @@ public class PlainRequest extends Operation {
 
         @Override
         public HttpRequestResponse call() throws Exception {
-            if(BurpUtils.getInstance().getFilterState().shouldProcess(BurpOperation.OUTGOING, EXTENSIONS)) {
-                HttpRequest requestWithCustomHeader = HttpRequest.httpRequest(service, data).withAddedHeader("X-CSTC-79301f837932346cb067c568e27369bf", "cstc");
-                return api.http().sendRequest(requestWithCustomHeader);
-            }
-
-            return api.http().sendRequest(HttpRequest.httpRequest(service, data));
+            HttpRequest requestWithCustomHeader = HttpRequest.httpRequest(service, data).withAddedHeader("X-CSTC-79301f837932346cb067c568e27369bf", "cstc");
+            return api.http().sendRequest(requestWithCustomHeader);
         }
 
     }

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpGetSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpGetSetter.java
@@ -18,11 +18,13 @@ public class HttpGetSetter extends SetterOperation {
     private JCheckBox urlEncodeAll;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = getWhere();
         if (parameterName.equals(""))
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpGetSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpGetSetter.java
@@ -20,11 +20,16 @@ public class HttpGetSetter extends SetterOperation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String parameterName = getWhere();
-        if (parameterName.equals(""))
-            return input;
-
         MessageType messageType = parseMessageType(input);
+
+        if(messageType == MessageType.RESPONSE) {
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
+        }
+
+        String parameterName = getWhere();
+        if (parameterName.equals("")) {
+            return input;
+        }
 
         if (messageType == MessageType.REQUEST) {
             try {
@@ -37,13 +42,11 @@ public class HttpGetSetter extends SetterOperation {
                     return input;
                 }
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Input is not a valid request.");
             }
-        } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
-        } else {
-            return parseRawMessage(input);
         }
+
+        return parseRawMessage(input);
     }
 
     @Override

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
@@ -25,9 +25,15 @@ public class HttpHeaderRemove extends Operation {
         }
 
         if(messageType == MessageType.REQUEST) {
+            if(!HttpRequest.httpRequest(input).hasHeader(headerName)) {
+                throw new IllegalArgumentException("Header not found.");
+            }
             return HttpRequest.httpRequest(input).withRemovedHeader(headerName).toByteArray();
         }
         else if(messageType == MessageType.RESPONSE) {
+            if(!HttpResponse.httpResponse(input).hasHeader(headerName)) {
+                throw new IllegalArgumentException("Header not found.");
+            }
             return HttpResponse.httpResponse(input).withRemovedHeader(headerName).toByteArray();
         }
         else {

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
@@ -1,0 +1,44 @@
+package de.usd.cstchef.operations.setter;
+
+import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.responses.HttpResponse;
+import de.usd.cstchef.Utils.MessageType;
+import de.usd.cstchef.operations.Operation;
+import de.usd.cstchef.operations.Operation.OperationInfos;
+import de.usd.cstchef.view.ui.VariableTextField;
+import de.usd.cstchef.operations.OperationCategory;
+
+@OperationInfos(name = "Remove HTTP Header", category = OperationCategory.SETTER, description = "Remove the specified HTTP Header.")
+public class HttpHeaderRemove extends Operation {
+
+    private VariableTextField header;
+
+    @Override
+    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+        String headerName = header.getText();
+
+        if(headerName.isEmpty()) {
+            return input;
+        }
+
+        if(messageType == MessageType.REQUEST) {
+            return HttpRequest.httpRequest(input).withRemovedHeader(headerName).toByteArray();
+        }
+        else if(messageType == MessageType.RESPONSE) {
+            return HttpResponse.httpResponse(input).withRemovedHeader(headerName).toByteArray();
+        }
+        else {
+            return parseRawMessage(input);
+        }
+    }
+
+
+    @Override
+    public void createUI() {
+        this.header = new VariableTextField();
+
+        this.addUIElement("Header Name", this.header);
+    }
+    
+}

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
@@ -17,13 +17,12 @@ public class HttpHeaderRemove extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String headerName = header.getText();
+        MessageType messageType = parseMessageType(input);
 
+        String headerName = header.getText();
         if(headerName.isEmpty()) {
             return input;
         }
-
-        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input).withRemovedHeader(headerName).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderRemove.java
@@ -15,12 +15,15 @@ public class HttpHeaderRemove extends Operation {
     private VariableTextField header;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
+
         String headerName = header.getText();
 
         if(headerName.isEmpty()) {
             return input;
         }
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input).withRemovedHeader(headerName).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderSetter.java
@@ -2,19 +2,13 @@ package de.usd.cstchef.operations.setter;
 
 import javax.swing.JCheckBox;
 
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.http.message.HttpHeader;
-import burp.api.montoya.http.message.params.HttpParameterType;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
-import burp.api.montoya.ui.editor.extension.HttpRequestEditorProvider;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.operations.extractors.JsonExtractor;
 
 @OperationInfos(name = "Set HTTP Header", category = OperationCategory.SETTER, description = "Set a HTTP header to the specified value.")
 public class HttpHeaderSetter extends SetterOperation {
@@ -22,12 +16,14 @@ public class HttpHeaderSetter extends SetterOperation {
     private JCheckBox addIfNotPresent;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String newValue = getWhat();
         String headerName = getWhere();
         if( headerName.length() == 0 )
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST){
             HttpRequest request = HttpRequest.httpRequest(input);

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpHeaderSetter.java
@@ -18,12 +18,13 @@ public class HttpHeaderSetter extends SetterOperation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String newValue = getWhat();
         String headerName = getWhere();
-        if( headerName.length() == 0 )
+        if( headerName.length() == 0 ) {
             return input;
-
-        MessageType messageType = parseMessageType(input);
+        }
 
         if(messageType == MessageType.REQUEST){
             HttpRequest request = HttpRequest.httpRequest(input);

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpJsonSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpJsonSetter.java
@@ -6,23 +6,15 @@ import java.awt.event.FocusListener;
 
 import javax.swing.JCheckBox;
 
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
-
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.HttpHeader;
 import burp.api.montoya.http.message.params.HttpParameter;
 import burp.api.montoya.http.message.params.HttpParameterType;
-import burp.api.montoya.http.message.params.ParsedHttpParameter;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.operations.extractors.JsonExtractor;
 import de.usd.cstchef.view.ui.VariableTextField;
 
 @OperationInfos(name = "Set HTTP JSON", category = OperationCategory.SETTER, description = "Set a JSON parameter to the specified value.")
@@ -32,11 +24,13 @@ public class HttpJsonSetter extends SetterOperation {
     private VariableTextField path;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = getWhere();
         if (parameterName.equals(""))
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input)

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpJsonSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpJsonSetter.java
@@ -26,11 +26,12 @@ public class HttpJsonSetter extends SetterOperation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String parameterName = getWhere();
-        if (parameterName.equals(""))
-            return input;
-
         MessageType messageType = parseMessageType(input);
+
+        String parameterName = getWhere();
+        if (parameterName.equals("")) {
+            return input;
+        }
 
         if (messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input)

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpMultipartSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpMultipartSetter.java
@@ -12,11 +12,13 @@ import de.usd.cstchef.operations.OperationCategory;
 public class HttpMultipartSetter extends SetterOperation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = getWhere();
         if (parameterName.equals(""))
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpMultipartSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpMultipartSetter.java
@@ -14,11 +14,16 @@ public class HttpMultipartSetter extends SetterOperation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String parameterName = getWhere();
-        if (parameterName.equals(""))
-            return input;
-
         MessageType messageType = parseMessageType(input);
+
+        if(messageType == MessageType.RESPONSE) {
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
+        }
+
+        String parameterName = getWhere();
+        if (parameterName.equals("")) {
+            return input;
+        }
 
         if (messageType == MessageType.REQUEST) {
             try {
@@ -26,13 +31,11 @@ public class HttpMultipartSetter extends SetterOperation {
                         .withParameter(HttpParameter.parameter(parameterName, getWhat(), HttpParameterType.BODY))
                         .toByteArray();
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Input is not a valid request.");
             }
-        } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
-        } else {
-            return parseRawMessage(input);
         }
+
+        return parseRawMessage(input);
 
     }
 }

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpPostSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpPostSetter.java
@@ -20,11 +20,16 @@ public class HttpPostSetter extends SetterOperation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        String parameterName = getWhere();
-        if (parameterName.equals(""))
-            return input;
-
         MessageType messageType = parseMessageType(input);
+
+        if(messageType == MessageType.RESPONSE) {
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
+        }
+
+        String parameterName = getWhere();
+        if (parameterName.equals("")) {
+            return input;
+        }
 
         if (messageType == MessageType.REQUEST) {
             try {
@@ -37,13 +42,11 @@ public class HttpPostSetter extends SetterOperation {
                     return input;
                 }
             } catch (Exception e) {
-                throw new IllegalArgumentException("Input is not a valid request");
+                throw new IllegalArgumentException("Input is not a valid request.");
             }
-        } else if (messageType == MessageType.RESPONSE) {
-            throw new IllegalArgumentException("Input is not a valid HTTP Request");
-        } else {
-            return parseRawMessage(input);
         }
+
+        return parseRawMessage(input);
     }
 
     @Override

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpPostSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpPostSetter.java
@@ -18,11 +18,13 @@ public class HttpPostSetter extends SetterOperation {
     private JCheckBox urlEncodeAll;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String parameterName = getWhere();
         if (parameterName.equals(""))
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if (messageType == MessageType.REQUEST) {
             try {

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetBody.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetBody.java
@@ -17,11 +17,12 @@ public class HttpSetBody extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
-        ByteArray replacementBody = replacementTxt.getText();
-        if( replacementBody.toString().equals("") )
-            return input;
-
         MessageType messageType = parseMessageType(input);
+
+        ByteArray replacementBody = replacementTxt.getText();
+        if(replacementBody.toString().equals("")) {
+            return input;
+        }
 
         if(messageType == MessageType.REQUEST){
             return HttpRequest.httpRequest(input).withBody(replacementBody).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetBody.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetBody.java
@@ -1,13 +1,6 @@
 package de.usd.cstchef.operations.setter;
 
-import java.util.Arrays;
-
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.HttpHeader;
-import burp.api.montoya.http.message.params.HttpParameter;
-import burp.api.montoya.http.message.params.HttpParameterType;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
@@ -22,10 +15,13 @@ public class HttpSetBody extends Operation {
     private FormatTextField replacementTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
+
         ByteArray replacementBody = replacementTxt.getText();
         if( replacementBody.toString().equals("") )
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST){
             return HttpRequest.httpRequest(input).withBody(replacementBody).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
@@ -15,17 +15,19 @@ import de.usd.cstchef.operations.OperationCategory;
 @OperationInfos(name = "Set HTTP Cookie", category = OperationCategory.SETTER, description = "Set a HTTP cookie to the specified value.")
 public class HttpSetCookie extends SetterOperation {
 
+    private JCheckBox removeIfNoValue;
     private JCheckBox addIfNotPresent;
 
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String cookieName = getWhere();
         String cookieValue = getWhat();
-        if (getWhat().equals(""))
+        if (cookieName.equals("")) {
             return input;
-
-        MessageType messageType = parseMessageType(input);
+        }
         
         if(messageType == MessageType.REQUEST) {
             HttpRequest request = HttpRequest.httpRequest(input);
@@ -38,6 +40,9 @@ public class HttpSetCookie extends SetterOperation {
                     String[] c = cookies.split("; ");
                     cookies = "";
                     for(String cookie : c) {
+                        if(removeIfNoValue.isSelected() && cookie.split("=")[0].equals(cookieName) && cookieValue.isEmpty()) {
+                            continue;
+                        }
                         cookie = cookie.replaceAll(cookieName + "=\\S*", cookieName + "=" + cookieValue);
                         cookies = cookies.concat(cookie + "; ");
                     }
@@ -67,6 +72,9 @@ public class HttpSetCookie extends SetterOperation {
                     if(httpHeader.get(i).name().equals("Set-Cookie")) {
                         // has this particular cookie set
                         if(httpHeader.get(i).value().contains(cookieName + "=")) {
+                            if(removeIfNoValue.isSelected() && cookieValue.isEmpty()) {
+                                continue;
+                            }
                             response = response.withAddedHeader("Set-Cookie", cookieName + "=" + cookieValue);
                         }
                         else{
@@ -95,9 +103,14 @@ public class HttpSetCookie extends SetterOperation {
     @Override
     public void createUI() {
         super.createUI();
+
+        this.removeIfNoValue = new JCheckBox("Remove if value is not set");
+        this.removeIfNoValue.setSelected(false);
+        this.addUIElement(null, this.removeIfNoValue, "checkbox1");
+
         this.addIfNotPresent = new JCheckBox("Add if not present");
-        this.addIfNotPresent.setSelected(true);
-        this.addUIElement(null, this.addIfNotPresent, "checkbox1");
+        this.addIfNotPresent.setSelected(false);
+        this.addUIElement(null, this.addIfNotPresent, "checkbox2");
     }
 
 }

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
@@ -15,7 +15,6 @@ import de.usd.cstchef.operations.OperationCategory;
 @OperationInfos(name = "Set HTTP Cookie", category = OperationCategory.SETTER, description = "Set a HTTP cookie to the specified value.")
 public class HttpSetCookie extends SetterOperation {
 
-    private JCheckBox removeIfNoValue;
     private JCheckBox addIfNotPresent;
 
     @Override
@@ -40,9 +39,6 @@ public class HttpSetCookie extends SetterOperation {
                     String[] c = cookies.split("; ");
                     cookies = "";
                     for(String cookie : c) {
-                        if(removeIfNoValue.isSelected() && cookie.split("=")[0].equals(cookieName) && cookieValue.isEmpty()) {
-                            continue;
-                        }
                         cookie = cookie.replaceAll(cookieName + "=\\S*", cookieName + "=" + cookieValue);
                         cookies = cookies.concat(cookie + "; ");
                     }
@@ -72,9 +68,6 @@ public class HttpSetCookie extends SetterOperation {
                     if(httpHeader.get(i).name().equals("Set-Cookie")) {
                         // has this particular cookie set
                         if(httpHeader.get(i).value().contains(cookieName + "=")) {
-                            if(removeIfNoValue.isSelected() && cookieValue.isEmpty()) {
-                                continue;
-                            }
                             response = response.withAddedHeader("Set-Cookie", cookieName + "=" + cookieValue);
                         }
                         else{
@@ -104,13 +97,9 @@ public class HttpSetCookie extends SetterOperation {
     public void createUI() {
         super.createUI();
 
-        this.removeIfNoValue = new JCheckBox("Remove if value is not set");
-        this.removeIfNoValue.setSelected(false);
-        this.addUIElement(null, this.removeIfNoValue, "checkbox1");
-
         this.addIfNotPresent = new JCheckBox("Add if not present");
-        this.addIfNotPresent.setSelected(false);
-        this.addUIElement(null, this.addIfNotPresent, "checkbox2");
+        this.addIfNotPresent.setSelected(true);
+        this.addUIElement(null, this.addIfNotPresent, "checkbox1");
     }
 
 }

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
@@ -4,16 +4,10 @@ import java.util.List;
 
 import javax.swing.JCheckBox;
 
-import burp.BurpUtils;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.Cookie;
 import burp.api.montoya.http.message.HttpHeader;
-import burp.api.montoya.http.message.params.HttpParameter;
-import burp.api.montoya.http.message.params.HttpParameterType;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -31,34 +25,68 @@ public class HttpSetCookie extends SetterOperation {
         if (getWhat().equals(""))
             return input;
 
-        if (messageType == MessageType.REQUEST) {
+        
+        if(messageType == MessageType.REQUEST) {
             HttpRequest request = HttpRequest.httpRequest(input);
-            if (!Utils.httpRequestCookieExtractor(request, cookieName).equals(ByteArray.byteArray(0))
-                    || addIfNotPresent.isSelected()) {
-                return Utils.addCookieToHttpRequest(request, new Utils.CSTCCookie(cookieName, cookieValue))
-                        .toByteArray();
-            } else {
-                return input;
-            }
-        } else if (messageType == MessageType.RESPONSE) {
-            HttpResponse response = HttpResponse.httpResponse(input);
-            List<HttpHeader> headers = response.headers();
-            for (HttpHeader h : headers) {
-                if (h.name().equals("Set-Cookie")) {
-                    if (h.value().contains(cookieName)) {
-                        return response.withRemovedHeader(h)
-                                .withAddedHeader(HttpHeader.httpHeader("Set-Cookie", cookieName + "=" + cookieValue))
-                                .toByteArray();
+
+            // has Cookie header
+            if(request.hasHeader("Cookie")) {
+                String cookies = request.header("Cookie").value();
+                // has this particular cookie set
+                if(cookies.contains(cookieName + "=")) {
+                    String[] c = cookies.split("; ");
+                    cookies = "";
+                    for(String cookie : c) {
+                        cookie = cookie.replaceAll(cookieName + "=\\S*", cookieName + "=" + cookieValue);
+                        cookies = cookies.concat(cookie + "; ");
                     }
+                    cookies = cookies.replaceAll(";\s$", "");
+                    return request.withUpdatedHeader("Cookie", cookies).toByteArray();
+                }
+                // has this particular cookie not set
+                else {
+                    cookies = cookies.concat("; " + cookieName + "=" + cookieValue);
+                        return addIfNotPresent.isSelected() ? request.withUpdatedHeader("Cookie", cookies).toByteArray() : input;
                 }
             }
-            if (addIfNotPresent.isSelected()) {
-                return response.withAddedHeader(HttpHeader.httpHeader("Set-Cookie", cookieName + "=" + cookieValue))
-                        .toByteArray();
-            } else {
-                return input;
+            // has no Cookie header
+            else {
+                return addIfNotPresent.isSelected() ? request.withAddedHeader("Cookie", cookieName + "=" + cookieValue).toByteArray() : input;
             }
-        } else {
+        }
+
+        else if (messageType == MessageType.RESPONSE) {
+            HttpResponse response = HttpResponse.httpResponse(input);
+            List<HttpHeader> httpHeader = response.headers();
+
+            // has Set-Cookie header
+            if(response.hasCookie(cookieName)) {
+                response = response.withRemovedHeaders(httpHeader);
+                for(int i = 0; i < httpHeader.size(); i++) {
+                    if(httpHeader.get(i).name().equals("Set-Cookie")) {
+                        // has this particular cookie set
+                        if(httpHeader.get(i).value().contains(cookieName + "=")) {
+                            response = response.withAddedHeader("Set-Cookie", cookieName + "=" + cookieValue);
+                        }
+                        else{
+                            response = response.withAddedHeader(httpHeader.get(i));
+                        }
+                    }
+                    else {
+                        response = response.withAddedHeader(httpHeader.get(i));
+                    }
+                }
+
+                return response.toByteArray();
+
+            }
+            // has no Set-Cookie header
+            else {
+                return addIfNotPresent.isSelected() ? response.withAddedHeader("Set-Cookie", cookieName + "=" + cookieValue).toByteArray(): input;
+            }
+        }
+        
+        else {
             return parseRawMessage(input);
         }
     }

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetCookie.java
@@ -18,13 +18,14 @@ public class HttpSetCookie extends SetterOperation {
     private JCheckBox addIfNotPresent;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String cookieName = getWhere();
         String cookieValue = getWhat();
         if (getWhat().equals(""))
             return input;
 
+        MessageType messageType = parseMessageType(input);
         
         if(messageType == MessageType.REQUEST) {
             HttpRequest request = HttpRequest.httpRequest(input);

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetUri.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetUri.java
@@ -29,10 +29,16 @@ public class HttpSetUri extends Operation {
 
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
-        if( this.uriTxt.getText().equals("") )
-            return input;
 
         MessageType messageType = parseMessageType(input);
+
+        if(messageType == MessageType.RESPONSE) {
+            throw new IllegalArgumentException("Input is not a valid HTTP request.");
+        }
+
+        if(this.uriTxt.getText().equals("")) {
+            return input;
+        }
 
         if(messageType == MessageType.REQUEST){
             try {
@@ -58,15 +64,11 @@ public class HttpSetUri extends Operation {
                 return newRequest;
     
             } catch (Exception e) {
-                throw new IllegalArgumentException("Provided input is not a valid http request.");
+                throw new IllegalArgumentException("Input is not a valid request");
             }
         }
-        else if(messageType == MessageType.RESPONSE){
-            throw new IllegalArgumentException("Provided input is not a valid http request.");
-        }
-        else{
-            return parseRawMessage(input);
-        }
+        
+        return parseRawMessage(input);
         
     }
 

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpSetUri.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpSetUri.java
@@ -1,14 +1,10 @@
 package de.usd.cstchef.operations.setter;
 
-import java.util.Arrays;
-
 import javax.swing.JCheckBox;
 
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.requests.HttpRequest;
-import burp.api.montoya.http.message.responses.HttpResponse;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -32,9 +28,11 @@ public class HttpSetUri extends Operation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         if( this.uriTxt.getText().equals("") )
             return input;
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST){
             try {

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpXmlSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpXmlSetter.java
@@ -22,14 +22,14 @@ public class HttpXmlSetter extends Operation {
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
 
+        MessageType messageType = parseMessageType(input);
+
         String p = this.path.getText();
         String v = this.value.getText();
 
         if(p.trim().isEmpty()) {
             return input;
         }
-
-        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input).withBody(Utils.xmlSetter(HttpRequest.httpRequest(input).body(), p, v, addIfNotPresent.isSelected())).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/HttpXmlSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/HttpXmlSetter.java
@@ -20,7 +20,7 @@ public class HttpXmlSetter extends Operation {
     private JCheckBox addIfNotPresent;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String p = this.path.getText();
         String v = this.value.getText();
@@ -28,6 +28,8 @@ public class HttpXmlSetter extends Operation {
         if(p.trim().isEmpty()) {
             return input;
         }
+
+        MessageType messageType = parseMessageType(input);
 
         if(messageType == MessageType.REQUEST) {
             return HttpRequest.httpRequest(input).withBody(Utils.xmlSetter(HttpRequest.httpRequest(input).body(), p, v, addIfNotPresent.isSelected())).toByteArray();

--- a/src/main/java/de/usd/cstchef/operations/setter/JsonSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/JsonSetter.java
@@ -10,7 +10,6 @@ import javax.swing.JCheckBox;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Utils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.view.ui.VariableTextField;
@@ -22,7 +21,7 @@ public class JsonSetter extends SetterOperation implements ActionListener {
     private VariableTextField path;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return Utils.jsonSetter(input, getWhere(), getWhat(), addIfNotPresent.isSelected(), path.getText());
     }
 

--- a/src/main/java/de/usd/cstchef/operations/setter/JsonSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/JsonSetter.java
@@ -22,7 +22,20 @@ public class JsonSetter extends SetterOperation implements ActionListener {
 
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
-        return Utils.jsonSetter(input, getWhere(), getWhat(), addIfNotPresent.isSelected(), path.getText());
+        if(getWhere().equals("")) {
+            return input;
+        }
+        try {
+            return Utils.jsonSetter(input, getWhere(), getWhat(), addIfNotPresent.isSelected(), path.getText());
+        }
+        catch(Exception e) {
+            if(e.getMessage().equals("json string can not be null or empty")) {
+                return input;
+            }
+            else {
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/de/usd/cstchef/operations/setter/LineSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/LineSetter.java
@@ -1,7 +1,5 @@
 package de.usd.cstchef.operations.setter;
 
-import java.util.Arrays;
-
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 
@@ -9,7 +7,6 @@ import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Utils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -20,7 +17,7 @@ public class LineSetter extends SetterOperation {
     private JComboBox<String> formatBox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         int lineNumber;
         try {

--- a/src/main/java/de/usd/cstchef/operations/setter/SetterOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/SetterOperation.java
@@ -2,7 +2,6 @@ package de.usd.cstchef.operations.setter;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.bouncycastle.util.encoders.Hex;
@@ -10,7 +9,6 @@ import org.bouncycastle.util.encoders.Hex;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.params.HttpParameter;
 import burp.api.montoya.http.message.params.HttpParameterType;
 import burp.api.montoya.http.message.params.ParsedHttpParameter;
 import burp.api.montoya.http.message.requests.HttpRequest;

--- a/src/main/java/de/usd/cstchef/operations/setter/XmlSetter.java
+++ b/src/main/java/de/usd/cstchef/operations/setter/XmlSetter.java
@@ -4,7 +4,6 @@ import javax.swing.JCheckBox;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.Utils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.view.ui.VariableTextField;
@@ -18,7 +17,7 @@ public class XmlSetter extends Operation {
     private JCheckBox addIfNotPresent;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String p = this.path.getText();
         String v = this.value.getText();

--- a/src/main/java/de/usd/cstchef/operations/signature/JWTDecode.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/JWTDecode.java
@@ -1,44 +1,21 @@
 package de.usd.cstchef.operations.signature;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
-import de.usd.cstchef.view.ui.VariableTextField;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.interfaces.RSAKey;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 
-import javax.swing.JComboBox;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-
-import org.apache.commons.lang3.NotImplementedException;
-
 import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.auth0.jwt.interfaces.RSAKeyProvider;
 
-import burp.Logger;
 import burp.api.montoya.core.ByteArray;
 
 @OperationInfos(name = "JWT Decode", category = OperationCategory.SIGNATURE, description = "Decode a given JWT payload and return its contents")
 public class JWTDecode extends Operation {
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		DecodedJWT content = JWT.decode(input.toString());		
 		return factory.createByteArray(Base64.getDecoder().decode(content.getPayload()));
 	}

--- a/src/main/java/de/usd/cstchef/operations/signature/JWTSign.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/JWTSign.java
@@ -46,6 +46,7 @@ public class JWTSign extends Operation implements ActionListener, DocumentListen
 		if(this.hasError) {			
 			throw new IllegalArgumentException("Key not valid");
 		}
+		this.reconfigureAlgorithmAndKey();
 		String token = JWT.create().withPayload(input.toString()).sign(this.currentAlgorithm);
 		return factory.createByteArray(token);
 	}

--- a/src/main/java/de/usd/cstchef/operations/signature/JWTSign.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/JWTSign.java
@@ -1,6 +1,5 @@
 package de.usd.cstchef.operations.signature;
 
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -9,14 +8,10 @@ import de.usd.cstchef.view.ui.VariableTextField;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.StringReader;
 import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 
@@ -28,9 +23,7 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.RSAKeyProvider;
 
-import burp.Logger;
 import burp.api.montoya.core.ByteArray;
 
 @OperationInfos(name = "JWT Sign", category = OperationCategory.SIGNATURE, description = "Sign a given JWT payload")
@@ -42,7 +35,7 @@ public class JWTSign extends Operation implements ActionListener, DocumentListen
 	private boolean hasError= false;
 	
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		if(this.hasError) {			
 			throw new IllegalArgumentException("Key not valid");
 		}

--- a/src/main/java/de/usd/cstchef/operations/signature/RsaSignature.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/RsaSignature.java
@@ -8,7 +8,6 @@ import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -26,7 +25,7 @@ public class RsaSignature extends KeystoreOperation {
         this.createMyUI();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         if( !this.keyAvailable.isSelected() )
             throw new IllegalArgumentException("No private key available.");

--- a/src/main/java/de/usd/cstchef/operations/signature/SM2Signature.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/SM2Signature.java
@@ -8,7 +8,6 @@ import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 
@@ -26,7 +25,7 @@ public class SM2Signature extends KeystoreOperation {
         this.createMyUI();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         if( !this.keyAvailable.isSelected() )
             throw new IllegalArgumentException("No private key available.");
 

--- a/src/main/java/de/usd/cstchef/operations/signature/SoapMultiSignature.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/SoapMultiSignature.java
@@ -44,7 +44,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.view.ui.FormatTextField;
@@ -141,7 +140,7 @@ public class SoapMultiSignature extends KeystoreOperation {
     }
 
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
       String signMethod = (String)signatureMethod.getSelectedItem();
       PrivateKeyEntry keyEntry = this.selectedEntry;

--- a/src/main/java/de/usd/cstchef/operations/signature/XmlFullSignature.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/XmlFullSignature.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.signature;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -14,7 +13,6 @@ import org.w3c.dom.Document;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 
 @OperationInfos(name = "Xml Full Signature", category = OperationCategory.SIGNATURE, description = "Create a XML signature over the whole document.")
@@ -24,7 +22,7 @@ public class XmlFullSignature extends XmlSignature {
       super();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
       DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
       dbf.setNamespaceAware(true);
       dbf.setXIncludeAware(false);

--- a/src/main/java/de/usd/cstchef/operations/signature/XmlMultiSignature.java
+++ b/src/main/java/de/usd/cstchef/operations/signature/XmlMultiSignature.java
@@ -13,7 +13,6 @@ import org.w3c.dom.Document;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.OperationCategory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 
 @OperationInfos(name = "Xml Multi Signature", category = OperationCategory.SIGNATURE, description = "Create a XML signature over specified fields.")
@@ -24,7 +23,7 @@ public class XmlMultiSignature extends XmlSignature {
       this.addIdSelectors();
     }
 
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
       DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
       dbf.setNamespaceAware(true);
       dbf.setXIncludeAware(false);

--- a/src/main/java/de/usd/cstchef/operations/string/Concatenate.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Concatenate.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.string;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.VariableStore;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
@@ -17,7 +16,7 @@ public class Concatenate extends Operation {
     protected VariableTextField delimiter;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         String delim = delimiter.getText();
         VariableStore.getInstance().setVariable("input", input);

--- a/src/main/java/de/usd/cstchef/operations/string/Length.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Length.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.string;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -10,7 +9,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Length extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return factory.createByteArray(String.valueOf(input.length()));
     }
 

--- a/src/main/java/de/usd/cstchef/operations/string/Lowercase.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Lowercase.java
@@ -1,8 +1,6 @@
 package de.usd.cstchef.operations.string;
 
-import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -11,7 +9,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Lowercase extends Operation {
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		try {
 			if(input != null) {
 				String inputStr = input.toString();

--- a/src/main/java/de/usd/cstchef/operations/string/Prefix.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Prefix.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.string;
 import java.io.ByteArrayOutputStream;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,7 +14,7 @@ public class Prefix extends Operation {
     private FormatTextField prefixTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         out.write(prefixTxt.getText().getBytes());
         out.write(input.getBytes());

--- a/src/main/java/de/usd/cstchef/operations/string/RemoveWhitespace.java
+++ b/src/main/java/de/usd/cstchef/operations/string/RemoveWhitespace.java
@@ -2,9 +2,7 @@ package de.usd.cstchef.operations.string;
 
 import javax.swing.JComboBox;
 
-import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,7 +13,7 @@ public class RemoveWhitespace extends Operation {
 	JComboBox<String> whitespaceSelection;
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		try {
 			if(input != null) {
 				String inputStr = input.toString();

--- a/src/main/java/de/usd/cstchef/operations/string/Replace.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Replace.java
@@ -5,7 +5,6 @@ import javax.swing.JCheckBox;
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -20,7 +19,7 @@ public class Replace extends Operation {
     private VariableTextArea replacementTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         ByteArray result = null;
         if( checkbox.isSelected() ) {

--- a/src/main/java/de/usd/cstchef/operations/string/Reverse.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Reverse.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.string;
 import org.bouncycastle.util.Arrays;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -12,7 +11,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Reverse extends Operation {
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		return factory.createByteArray(Arrays.reverse(input.getBytes()));
 	}
 

--- a/src/main/java/de/usd/cstchef/operations/string/SplitAndSelect.java
+++ b/src/main/java/de/usd/cstchef/operations/string/SplitAndSelect.java
@@ -1,11 +1,8 @@
 package de.usd.cstchef.operations.string;
 
-import org.bouncycastle.util.Arrays;
-
 import burp.BurpUtils;
 import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -18,7 +15,7 @@ public class SplitAndSelect extends Operation {
     private VariableTextField delim;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         ByteArray delimmiter = delim.getBytes();
 

--- a/src/main/java/de/usd/cstchef/operations/string/StaticString.java
+++ b/src/main/java/de/usd/cstchef/operations/string/StaticString.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.string;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -13,7 +12,7 @@ public class StaticString extends Operation {
     private VariableTextArea stringTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return this.stringTxt.getBytes();
     }
 

--- a/src/main/java/de/usd/cstchef/operations/string/Strip.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Strip.java
@@ -2,9 +2,7 @@ package de.usd.cstchef.operations.string;
 
 import javax.swing.JComboBox;
 
-import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,7 +13,7 @@ public class Strip extends Operation {
 	JComboBox<String> stripLocationSelection;
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		try {
 			if(input != null) {
 				String inputStr = input.toString();

--- a/src/main/java/de/usd/cstchef/operations/string/Substring.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Substring.java
@@ -3,11 +3,8 @@ package de.usd.cstchef.operations.string;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
-import org.bouncycastle.util.Arrays;
-
 import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -19,7 +16,7 @@ public class Substring extends Operation {
     private JSpinner endSpinner;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         int start = (int) startSpinner.getValue();
         int end = (int) endSpinner.getValue();

--- a/src/main/java/de/usd/cstchef/operations/string/Substring.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Substring.java
@@ -1,6 +1,7 @@
 package de.usd.cstchef.operations.string;
 
 import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
 
 import org.bouncycastle.util.Arrays;
 
@@ -23,12 +24,8 @@ public class Substring extends Operation {
         int start = (int) startSpinner.getValue();
         int end = (int) endSpinner.getValue();
 
-        if( start < 0 )
-            start = input.length() + start;
-        if( end < 0 )
-            end = input.length() + end;
-        if( end > input.length() )
-            end = input.length() + 1;
+        if(input.length() + start < 0) throw new IllegalArgumentException("Start index out of bounds for input length " + input.length() + ".");
+        if(end > input.length()) throw new IllegalArgumentException("End index out of bounds for input length " + input.length() + ".");
 
         ByteArray slice = BurpUtils.subArray(input, start, end);
         return slice;
@@ -36,10 +33,12 @@ public class Substring extends Operation {
 
     @Override
     public void createUI() {
-        this.startSpinner = new JSpinner();
+        SpinnerNumberModel startIndexModel = new SpinnerNumberModel(0, 0, Integer.MAX_VALUE, 1);
+        this.startSpinner = new JSpinner(startIndexModel);
         this.addUIElement("Start", this.startSpinner);
 
-        this.endSpinner = new JSpinner();
+        SpinnerNumberModel endIndexModel = new SpinnerNumberModel(0, 0, Integer.MAX_VALUE, 1);
+        this.endSpinner = new JSpinner(endIndexModel);
         this.addUIElement("End", this.endSpinner);
     }
 

--- a/src/main/java/de/usd/cstchef/operations/string/Suffix.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Suffix.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.string;
 import java.io.ByteArrayOutputStream;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -15,7 +14,7 @@ public class Suffix extends Operation {
     private FormatTextField  suffixTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         out.write(input.getBytes());
         out.write(suffixTxt.getText().getBytes());

--- a/src/main/java/de/usd/cstchef/operations/string/Uppercase.java
+++ b/src/main/java/de/usd/cstchef/operations/string/Uppercase.java
@@ -1,8 +1,6 @@
 package de.usd.cstchef.operations.string;
 
-import burp.BurpUtils;
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -11,7 +9,7 @@ import de.usd.cstchef.operations.Operation.OperationInfos;
 public class Uppercase extends Operation {
 
 	@Override
-	protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+	protected ByteArray perform(ByteArray input) throws Exception {
 		try {
 			if(input != null) {
 				String inputStr = input.toString();

--- a/src/main/java/de/usd/cstchef/operations/utils/Counter.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/Counter.java
@@ -1,12 +1,8 @@
 package de.usd.cstchef.operations.utils;
 
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-
 import javax.swing.JTextField;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.VariableStore;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
@@ -20,7 +16,7 @@ public class Counter extends Operation {
     private JTextField stepSizeTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String varName = this.varNameTxt.getText().trim();
         long value;
         long stepSize = Long.valueOf(this.stepSizeTxt.getText());

--- a/src/main/java/de/usd/cstchef/operations/utils/GetVariable.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/GetVariable.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.utils;
 import javax.swing.JTextField;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.VariableStore;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
@@ -16,7 +15,7 @@ public class GetVariable extends Operation {
     private JTextField defaultTxt;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String varName = this.varNameTxt.getText().trim();
         ByteArray var = VariableStore.getInstance().getVariable(varName);
         return var == null ? factory.createByteArray(this.defaultTxt.getText()) : var;

--- a/src/main/java/de/usd/cstchef/operations/utils/NoOperation.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/NoOperation.java
@@ -1,7 +1,6 @@
 package de.usd.cstchef.operations.utils;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -10,7 +9,7 @@ import de.usd.cstchef.operations.OperationCategory;
 public class NoOperation extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         return input;
     }
 

--- a/src/main/java/de/usd/cstchef/operations/utils/RandomNumber.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/RandomNumber.java
@@ -3,12 +3,9 @@ package de.usd.cstchef.operations.utils;
 import java.security.SecureRandom;
 import java.text.NumberFormat;
 
-import javax.swing.JSeparator;
 import javax.swing.JTextField;
-import javax.swing.SwingConstants;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -45,7 +42,7 @@ public class RandomNumber extends Operation {
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         // get Bounds from user input
         int boundMin = parseInt(this.textFieldMinimum.getText(), 0);

--- a/src/main/java/de/usd/cstchef/operations/utils/RandomUUID.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/RandomUUID.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.utils;
 import java.util.UUID;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -12,7 +11,7 @@ import de.usd.cstchef.operations.OperationCategory;
 public class RandomUUID extends Operation {
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         final String uuid = UUID.randomUUID().toString();
         return factory.createByteArray(uuid);
     }

--- a/src/main/java/de/usd/cstchef/operations/utils/SetIfEmpty.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/SetIfEmpty.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.utils;
 import javax.swing.JCheckBox;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.operations.OperationCategory;
@@ -16,7 +15,7 @@ public class SetIfEmpty extends Operation {
     private JCheckBox checkbox;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
 
         ByteArray valueToSet = value.getText();
         if( input.length() == 0 ) {

--- a/src/main/java/de/usd/cstchef/operations/utils/StoreVariable.java
+++ b/src/main/java/de/usd/cstchef/operations/utils/StoreVariable.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.operations.utils;
 import javax.swing.JTextField;
 
 import burp.api.montoya.core.ByteArray;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.VariableStore;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
@@ -16,7 +15,7 @@ public class StoreVariable extends Operation {
     private String oldVarName;
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         String newVarName = this.varNameTxt.getText().trim();
         VariableStore store = VariableStore.getInstance();
         // remove old variable from hashmap

--- a/src/main/java/de/usd/cstchef/view/OperationsTree.java
+++ b/src/main/java/de/usd/cstchef/view/OperationsTree.java
@@ -21,7 +21,6 @@ import de.usd.cstchef.Utils;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
-import de.usd.cstchef.view.filter.FilterState.BurpOperation;
 
 public class OperationsTree extends JTree {
 
@@ -29,11 +28,9 @@ public class OperationsTree extends JTree {
     private static ImageIcon nodeIcon = new ImageIcon(Operation.class.getResource("/operation.png"));
     private static ImageIcon openIcon = new ImageIcon(Operation.class.getResource("/folder_open.png"));
     private static ImageIcon closedIcon = new ImageIcon(Operation.class.getResource("/folder_closed.png"));
-    private BurpOperation operation;
 
-    public OperationsTree(BurpOperation operation) {
+    public OperationsTree() {
         super();
-        this.operation = operation;
         this.setUI(new CustomTreeUI());
         this.model = (DefaultTreeModel) this.getModel();
         this.model.setRoot(this.createTree());
@@ -127,8 +124,7 @@ public class OperationsTree extends JTree {
         }
 
         // TODO add operations to categories - reflections do not work in burp :(
-        // pass the operation parameter so that separate operation trees can be defined for incoming/outgoing/formatting
-        Class<? extends Operation>[] operations = Utils.getOperations(this.operation);
+        Class<? extends Operation>[] operations = Utils.getOperations();
         for (Class<? extends Operation> operation : operations) {
             OperationInfos operationInfos = operation.getAnnotation(OperationInfos.class);
             if (operationInfos == null) {

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -486,7 +486,6 @@ public class RecipePanel extends JPanel implements ChangeListener {
         this.controllerOrig.setHttpRequestResponse(requestResponse);
         this.controllerMod.setHttpRequestResponse(requestResponse);
 
-        this.bake(false);
     }
 
     public void setFormatMessage(HttpRequestResponse requestResponse, MessageType messageType){

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -543,7 +543,10 @@ public class RecipePanel extends JPanel implements ChangeListener {
                 // check if it is an operation
                 Operation op = cls.newInstance();
                 op.load(parameters);
-                op.setDisabled(!operationNode.get("is_enabled").asBoolean());
+
+                if(operationNode.get("is_enabled") != null) {
+                    op.setDisabled(!operationNode.get("is_enabled").asBoolean());
+                }
 
                 // check if "comment" attribute is set (since 1.3.2)
                 if(operationNode.get("comment") != null) {

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -645,9 +645,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
     }
 
     private ByteArray doBake(ByteArray input, MessageType messageType) {
-        if (input == null || input.length() == 0) {
-            return ByteArray.byteArrayOfLength(0);
-        }
+        
         ByteArray result = input.copy();
         ByteArray intermediateResult = input;
         boolean outputChanged;
@@ -692,37 +690,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
             }
         }
 
-        if (BurpUtils.inBurp()) {
-            MontoyaApi api = BurpUtils.getInstance().getApi();
-            HttpRequest req;
-            List<HttpHeader> headers;
-            int offset;
-            try {
-                req = HttpRequest.httpRequest(result);
-                headers = req.headers();
-                offset = req.bodyOffset();
-            } catch( IllegalArgumentException e ) {
-                // In this case there is no valid HTTP request and no Content-Length update is requried.
-                return result;
-            }
-
-            if( result.length() == offset ) {
-                // In this case there is no body and we do not need to update the content length header.
-                return result;
-            }
-
-            for(HttpHeader header : headers) {
-                if(header.toString().startsWith("Content-Length:")) {
-                    HttpParameter dummy = HttpParameter.bodyParameter("dummy", "dummy");
-                    result = HttpRequest.httpRequest(result).withAddedParameters(dummy).withRemovedParameters(dummy).toByteArray();
-                    break;
-                }
-            }
-            return result;
-
-        } else {
-            return result;
-        }
+        return result;
     }
 
     private void bake(boolean spamProtection) {

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -13,7 +13,6 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -23,59 +22,42 @@ import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
-import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.type.PlaceholderForType;
 
-import burp.BurpExtender;
 import burp.BurpUtils;
 import burp.CstcMessageEditorController;
 import burp.Logger;
-import burp.api.montoya.MontoyaApi;
 import burp.api.montoya.core.BurpSuiteEdition;
 import burp.api.montoya.core.ByteArray;
-import burp.api.montoya.http.message.HttpHeader;
-import burp.api.montoya.http.message.HttpMessage;
 import burp.api.montoya.http.message.HttpRequestResponse;
-import burp.api.montoya.http.message.params.HttpParameter;
-import burp.api.montoya.http.message.params.ParsedHttpParameter;
 import burp.api.montoya.http.message.requests.HttpRequest;
 import burp.api.montoya.http.message.responses.HttpResponse;
 import burp.api.montoya.persistence.PersistedObject;
-import de.usd.cstchef.Utils;
 import de.usd.cstchef.VariableStore;
 import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.Operation;
-import de.usd.cstchef.view.filter.FilterState;
 import de.usd.cstchef.view.filter.FilterState.BurpOperation;
 import de.usd.cstchef.view.ui.PlaceholderTextField;
 import de.usd.cstchef.view.ui.TextChangedListener;
 
 public class RecipePanel extends JPanel implements ChangeListener {
-
-    private static Logger logger = Logger.getInstance();
 
     private int operationSteps = 10;
     private boolean autoBake = true;
@@ -148,8 +130,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
         PlaceholderTextField searchText = new PlaceholderTextField("Search");
         searchTreePanel.add(searchText, BorderLayout.PAGE_START);
 
-        // pass the operation parameter so that separate operation trees can be defined for incoming/outgoing/formatting
-        OperationsTree operationsTree = new OperationsTree(operation);
+        OperationsTree operationsTree = new OperationsTree();
         operationsTree.setRootVisible(false);
         searchTreePanel.add(new JScrollPane(operationsTree));
         searchText.addTextChangedListener(new TextChangedListener() {

--- a/src/main/java/de/usd/cstchef/view/View.java
+++ b/src/main/java/de/usd/cstchef/view/View.java
@@ -11,7 +11,6 @@ import javax.swing.WindowConstants;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import burp.BurpUtils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.view.filter.FilterState;
 import de.usd.cstchef.view.filter.FilterState.BurpOperation;
 
@@ -31,9 +30,9 @@ public class View extends JPanel {
         this.setLayout(new BorderLayout());
         JTabbedPane tabbedPane = new JTabbedPane();
 
-        incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING, MessageType.RESPONSE);
-        outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING, MessageType.REQUEST);
-        formatRecipePanel = new RecipePanel(BurpOperation.FORMAT, MessageType.RAW);
+        incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING);
+        outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING);
+        formatRecipePanel = new RecipePanel(BurpOperation.FORMAT);
 
         tabbedPane.addTab("Outgoing Requests", null, outgoingRecipePanel, "Outgoing requests from the browser, the repeater or another tool.");
         tabbedPane.addTab("Incoming Responses", null, incomingRecipePanel, "Responses from the server.");

--- a/src/main/java/de/usd/cstchef/view/filter/FilterState.java
+++ b/src/main/java/de/usd/cstchef/view/filter/FilterState.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import burp.api.montoya.core.ToolSource;
+import burp.api.montoya.core.ToolType;
 
 public class FilterState implements Serializable{
     @JsonDeserialize(keyUsing = FilterStateDeserializer.class)
@@ -54,9 +54,8 @@ public class FilterState implements Serializable{
         this.outgoingFilterSettings = outgoingFilterMask;
     }
 
-    public boolean shouldProcess(BurpOperation operation, ToolSource toolSource) {
+    public boolean shouldProcess(BurpOperation operation, ToolType toolType) {
         LinkedHashMap<Filter, Boolean> filterSettings;
-        int filterMask = 0;
         switch (operation) {
             case INCOMING:
                 filterSettings = incomingFilterSettings;
@@ -71,7 +70,7 @@ public class FilterState implements Serializable{
 
         for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
             Filter filter = entry.getKey();
-            if(filter.getToolType().equals(toolSource.toolType())){
+            if(filter.getToolType() == toolType){
                 return entry.getValue() == true;
             }
         }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/AdditionTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/AdditionTest.java
@@ -35,7 +35,7 @@ public class AdditionTest extends Addition
         isFloat = false;
 
         String testValue = "22";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("32");
     }
@@ -47,7 +47,7 @@ public class AdditionTest extends Addition
         isFloat = true;
 
         String testValue = "2.2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("4.4");
     }
@@ -59,7 +59,7 @@ public class AdditionTest extends Addition
         isFloat = false;
 
         String testValue = "2.2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("4");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/DivideListTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/DivideListTest.java
@@ -40,7 +40,7 @@ public class DivideListTest extends DivideList
         isFloat = false;
 
         String testValue = "8,2,4";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("1");
     }
@@ -52,7 +52,7 @@ public class DivideListTest extends DivideList
         isFloat = true;
 
         String testValue = "8,2,4,2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.5");
     }
@@ -64,7 +64,7 @@ public class DivideListTest extends DivideList
         isFloat = false;
 
         String testValue = "8 2 4 0.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("2");
     }
@@ -76,7 +76,7 @@ public class DivideListTest extends DivideList
         isFloat = true;
 
         String testValue = "8 2 4 4 0.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.5");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/DivideTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/DivideTest.java
@@ -41,7 +41,7 @@ public class DivideTest extends Divide
         isReverse = false;
 
         String testValue = "4";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("2");
     }
@@ -54,7 +54,7 @@ public class DivideTest extends Divide
         isReverse = true;
 
         String testValue = "4";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.5");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/MeanTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/MeanTest.java
@@ -40,7 +40,7 @@ public class MeanTest extends Mean
         isFloat = false;
 
         String testValue = "8,2,5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("5");
     }
@@ -52,7 +52,7 @@ public class MeanTest extends Mean
         isFloat = true;
 
         String testValue = "0.2,0.3,0.4,0.1";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.25");
     }
@@ -64,7 +64,7 @@ public class MeanTest extends Mean
         isFloat = false;
 
         String testValue = "8 2 5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("5");
     }
@@ -76,7 +76,7 @@ public class MeanTest extends Mean
         isFloat = true;
 
         String testValue = "0.2 0.3 0.4 0.1";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.25");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/MedianTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/MedianTest.java
@@ -40,7 +40,7 @@ public class MedianTest extends Median
         isFloat = false;
 
         String testValue = "1,2,3,4,5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("3");
     }
@@ -52,7 +52,7 @@ public class MedianTest extends Median
         isFloat = true;
 
         String testValue = "1,2,3.5,4,5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("3.5");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/MultiplyListTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/MultiplyListTest.java
@@ -40,7 +40,7 @@ public class MultiplyListTest extends MultiplyList
         isFloat = false;
 
         String testValue = "1,2,3,4,5,6";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("720");
     }
@@ -52,7 +52,7 @@ public class MultiplyListTest extends MultiplyList
         isFloat = true;
 
         String testValue = "3,0.5,0.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.75");
     }
@@ -64,7 +64,7 @@ public class MultiplyListTest extends MultiplyList
         isFloat = false;
 
         String testValue = "1 2 3 4 5 6";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         System.out.println(result.toString());
         assert result.toString().equals("720");
@@ -77,7 +77,7 @@ public class MultiplyListTest extends MultiplyList
         isFloat = true;
 
         String testValue = "3 0.5 0.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("0.75");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/MultiplyTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/MultiplyTest.java
@@ -34,7 +34,7 @@ public class MultiplyTest extends Multiply
         isFloat = false;
 
         String testValue = "22";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("220");
     }
@@ -46,7 +46,7 @@ public class MultiplyTest extends Multiply
         isFloat = true;
 
         String testValue = "2.2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().startsWith("4.84");
     }
@@ -58,7 +58,7 @@ public class MultiplyTest extends Multiply
         isFloat = false;
 
         String testValue = "2.2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("5");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/SubtractionTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/SubtractionTest.java
@@ -38,7 +38,7 @@ public class SubtractionTest extends Subtraction
         isFloat = false;
 
         String testValue = "22";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("12");
     }
@@ -50,7 +50,7 @@ public class SubtractionTest extends Subtraction
         isFloat = true;
 
         String testValue = "2.2";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         System.out.println(result.toString());
         assert result.toString().startsWith("0.1");
@@ -63,7 +63,7 @@ public class SubtractionTest extends Subtraction
         isFloat = false;
 
         String testValue = "2.8";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("1");
     }

--- a/src/test/java/de/usd/cstchef/operations/arithmetic/SumTest.java
+++ b/src/test/java/de/usd/cstchef/operations/arithmetic/SumTest.java
@@ -40,7 +40,7 @@ public class SumTest extends Sum
         isFloat = false;
 
         String testValue = "1,2,3,4,5,6";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("21");
     }
@@ -52,7 +52,7 @@ public class SumTest extends Sum
         isFloat = true;
 
         String testValue = "1,2,3,4,5,6";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("21.0");
     }
@@ -64,7 +64,7 @@ public class SumTest extends Sum
         isFloat = false;
 
         String testValue = "1.0 2.1 3.2 4.3 5.4 6.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("23");
     }
@@ -76,7 +76,7 @@ public class SumTest extends Sum
         isFloat = true;
 
         String testValue = "1.0 2.1 3.2 4.3 5.4 6.5";
-        ByteArray result = perform(factory.createByteArray(testValue), null);
+        ByteArray result = perform(factory.createByteArray(testValue));
 
         assert result.toString().equals("22.5");
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpBodyExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpBodyExtractorTest.java
@@ -31,11 +31,11 @@ public class HttpBodyExtractorTest extends HttpBodyExtractor {
             ByteArray inputArray = factory.createByteArray(inp);
             MessageType messageType = parseMessageType(inputArray);
             if(res.getValue1()) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals(messageType == MessageType.REQUEST ? "HTTP Request has no body." : "HTTP Response has no body.", exception.getMessage());
             }
             else {
-                assertArrayEquals(factory.createByteArray(res.getValue0()).getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(factory.createByteArray(res.getValue0()).getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpBodyExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpBodyExtractorTest.java
@@ -32,7 +32,7 @@ public class HttpBodyExtractorTest extends HttpBodyExtractor {
             MessageType messageType = parseMessageType(inputArray);
             if(res.getValue1()) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals(messageType == MessageType.REQUEST ? "HTTP Request has no body." : "HTTP Response has no body.", exception.getMessage());
+                assertEquals(messageType == MessageType.REQUEST ? "HTTP request has no body." : "HTTP response has no body.", exception.getMessage());
             }
             else {
                 assertArrayEquals(factory.createByteArray(res.getValue0()).getBytes(), perform(inputArray).getBytes());

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
@@ -15,7 +15,6 @@ import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.utils.UnitTestObjectFactory;
 import de.usd.cstchef.Utils;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.OperationCategory;
 
 @OperationInfos(name = "HttpCookieExtractorTest", category = OperationCategory.EXTRACTORS, description = "Test class")
@@ -30,14 +29,13 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
             Triplet<String, String, Boolean> res = inputs.get(inp);
             ByteArray inputArray = factory.createByteArray(inp);
             ByteArray outputArray = factory.createByteArray(res.getValue0());
-            MessageType messageType = parseMessageType(inputArray);
             this.cookieNameField.setText(res.getValue1());
             if (res.getValue2()) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Parameter name not found.", exception.getMessage());
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
@@ -101,7 +101,8 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
         String resIn1 = """
                 HTTP/2 200 Ok
                 Header1: a
-                Set-Cookie: cookie1=value1; cookie2=value2
+                Set-Cookie: cookie1=value1
+                Set-Cookie: cookie2=value2
 
                 """;
         String resOut1 = "value1";
@@ -112,7 +113,8 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
         String resIn2 = """
                 HTTP/2 200 Ok
                 Header1: b
-                Set-Cookie: cookie1=value1; cookie2=value2
+                Set-Cookie: cookie1=value1
+                Set-Cookie: cookie2=value2
 
                 """;
         String resOut2 = "value2";
@@ -123,18 +125,20 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
         String resIn3 = """
                 HTTP/2 200 Ok
                 Header1: c
-                Set-Cookie: cookie1=value1; cookie2=value2
+                Set-Cookie: cookie1=value1
+                Set-Cookie: cookie2=value2
 
                 """;
         String resOut3 = "";
         String resCookie3 = "cookie3";
-        Triplet<String, String, Boolean> resTriplet3 = new Triplet<String,String,Boolean>(resOut3, resCookie3, false);
+        Triplet<String, String, Boolean> resTriplet3 = new Triplet<String,String,Boolean>(resOut3, resCookie3, true);
 
         // empty cookieName
         String resIn4 = """
                 HTTP/2 200 Ok
                 Header1: d
-                Set-Cookie: cookie1=value1; cookie2=value2
+                Set-Cookie: cookie1=value1
+                Set-Cookie: cookie2=value2
 
                 """;
         String resOut4 = "";

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpCookieExtractorTest.java
@@ -32,7 +32,7 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
             this.cookieNameField.setText(res.getValue1());
             if (res.getValue2()) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Parameter name not found.", exception.getMessage());
+                assertEquals("Cookie not found.", exception.getMessage());
             }
             else{
                 assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
@@ -91,9 +91,8 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
 
 
                 """;
-        String reqOut4 = "";
         String reqCookie4 = "";
-        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String, String, Boolean>(reqOut4, reqCookie4, false);
+        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String, String, Boolean>(reqIn4, reqCookie4, false);
 
         // cookie1
         String resIn1 = """
@@ -139,9 +138,8 @@ public class HttpCookieExtractorTest extends HttpCookieExtractor {
                 Set-Cookie: cookie2=value2
 
                 """;
-        String resOut4 = "";
         String resCookie4 = "";
-        Triplet<String, String, Boolean> resTriplet4 = new Triplet<String,String,Boolean>(resOut4, resCookie4, false);
+        Triplet<String, String, Boolean> resTriplet4 = new Triplet<String,String,Boolean>(resIn4, resCookie4, false);
 
         inputs.put(reqIn1, reqTriplet1);
         inputs.put(reqIn2, reqTriplet2);

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpGetExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpGetExtractorTest.java
@@ -35,11 +35,11 @@ public class HttpGetExtractorTest extends HttpGetExtractor {
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
                     Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                    assertEquals("Parameter name not found.", exception.getMessage());
+                    assertEquals("GET parameter not found.", exception.getMessage());
                 }
                 else{
                     Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                    assertEquals("Input is not a valid HTTP Request", exception.getMessage());
+                    assertEquals("Input is not a valid HTTP request.", exception.getMessage());
                 }
             }
             else{
@@ -94,9 +94,8 @@ public class HttpGetExtractorTest extends HttpGetExtractor {
 
 
                 """;
-        String reqOut4 = "";
         String reqParam4 = "";
-        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String,String,Boolean>(reqOut4, reqParam4, false);
+        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String,String,Boolean>(reqIn4, reqParam4, false);
 
         // HTTP Response
         String resIn1 = """

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpGetExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpGetExtractorTest.java
@@ -34,16 +34,16 @@ public class HttpGetExtractorTest extends HttpGetExtractor {
             this.parameter.setText(res.getValue1());
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
-                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                     assertEquals("Parameter name not found.", exception.getMessage());
                 }
                 else{
-                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                     assertEquals("Input is not a valid HTTP Request", exception.getMessage());
                 }
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractorTest.java
@@ -14,7 +14,6 @@ import burp.CstcObjectFactory;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.utils.UnitTestObjectFactory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.OperationCategory;
 
 @OperationInfos(name = "HttpHeaderExtractorTest", category = OperationCategory.EXTRACTORS, description = "Test class")
@@ -29,15 +28,14 @@ public class HttpHeaderExtractorTest extends HttpHeaderExtractor {
             Triplet<String, String, Boolean> res = inputs.get(inp);
             ByteArray inputArray = factory.createByteArray(inp);
             ByteArray outputArray = factory.createByteArray(res.getValue0());
-            MessageType messageType = parseMessageType(inputArray);
             this.headerNameField.setText(res.getValue1());
             if (res.getValue2()) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Parameter name not found.", exception.getMessage());
             }
             else{
                 //assertEquals(perform(inputArray, messageType), outputArray);
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpHeaderExtractorTest.java
@@ -31,7 +31,7 @@ public class HttpHeaderExtractorTest extends HttpHeaderExtractor {
             this.headerNameField.setText(res.getValue1());
             if (res.getValue2()) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Parameter name not found.", exception.getMessage());
+                assertEquals("Header not found.", exception.getMessage());
             }
             else{
                 //assertEquals(perform(inputArray, messageType), outputArray);
@@ -90,9 +90,8 @@ public class HttpHeaderExtractorTest extends HttpHeaderExtractor {
 
                 d
                 """;
-        String reqOut4 = "";
         String reqHeader4 = "";
-        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String,String,Boolean>(reqOut4, reqHeader4, false);
+        Triplet<String, String, Boolean> reqTriplet4 = new Triplet<String,String,Boolean>(reqIn4, reqHeader4, false);
 
         // HTTP Response - Header2
         String resIn1 = """

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpMethodExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpMethodExtractorTest.java
@@ -14,7 +14,6 @@ import burp.CstcObjectFactory;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.utils.UnitTestObjectFactory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.OperationCategory;
 
 @OperationInfos(name = "HttpMethodExtractorTest", category = OperationCategory.EXTRACTORS, description = "Test class")
@@ -29,13 +28,12 @@ public class HttpMethodExtractorTest extends HttpMethodExtractor {
             Pair<String, Boolean> res = inputs.get(inp);
             ByteArray inputArray = factory.createByteArray(inp);
             ByteArray outputArray = factory.createByteArray(res.getValue0());
-            MessageType messageType = parseMessageType(inputArray);
             if (res.getValue1()) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Input is not a valid HTTP Request", exception.getMessage());
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpMethodExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpMethodExtractorTest.java
@@ -30,7 +30,7 @@ public class HttpMethodExtractorTest extends HttpMethodExtractor {
             ByteArray outputArray = factory.createByteArray(res.getValue0());
             if (res.getValue1()) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Input is not a valid HTTP Request", exception.getMessage());
+                assertEquals("Input is not a valid HTTP request.", exception.getMessage());
             }
             else{
                 assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractorTest.java
@@ -33,16 +33,16 @@ public class HttpMultipartExtractorTest extends HttpMultipartExtractor {
             this.parameter.setText(res.getValue1());
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
-                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                     assertEquals("Input is not a valid request", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Input is not a valid HTTP Request", exception.getMessage());
                 }
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpMultipartExtractorTest.java
@@ -34,11 +34,11 @@ public class HttpMultipartExtractorTest extends HttpMultipartExtractor {
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
                     Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                    assertEquals("Input is not a valid request", exception.getMessage());
+                    assertEquals("Parameter name not found.", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Input is not a valid HTTP Request", exception.getMessage());
+                assertEquals("Input is not a valid HTTP request.", exception.getMessage());
                 }
             }
             else{
@@ -174,9 +174,8 @@ public class HttpMultipartExtractorTest extends HttpMultipartExtractor {
             
             -----2a8ae6ad
                 """;
-        String reqOut5 = "";
         String reqParam5 = "";
-        Triplet<String, String, Boolean> reqTriplet5 = new Triplet<String, String, Boolean>(reqOut5, reqParam5, false);
+        Triplet<String, String, Boolean> reqTriplet5 = new Triplet<String, String, Boolean>(reqIn5, reqParam5, false);
 
         // HTTP Response
         String resIn1 = """

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpPostExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpPostExtractorTest.java
@@ -35,11 +35,11 @@ public class HttpPostExtractorTest extends HttpPostExtractor {
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
                     Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                    assertEquals("Input is not a valid request", exception.getMessage());
+                    assertEquals("POST parameter not found.", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Input is not a valid HTTP Request", exception.getMessage());
+                assertEquals("Input is not a valid HTTP request.", exception.getMessage());
                 }
             }
             else{
@@ -74,9 +74,8 @@ public class HttpPostExtractorTest extends HttpPostExtractor {
 
             param1=value1&param2=value2
             """;
-        String reqOut2 = "";
         String reqParam2 = "";
-        Triplet<String, String,  Boolean> reqTriplet2 = new Triplet<String, String, Boolean>(reqOut2, reqParam2, false);
+        Triplet<String, String,  Boolean> reqTriplet2 = new Triplet<String, String, Boolean>(reqIn2, reqParam2, false);
 
         // param not found
         String reqIn3 = """

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpPostExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpPostExtractorTest.java
@@ -34,16 +34,16 @@ public class HttpPostExtractorTest extends HttpPostExtractor {
             this.parameter.setText(res.getValue1());
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
-                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                     assertEquals("Input is not a valid request", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Input is not a valid HTTP Request", exception.getMessage());
                 }
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpUriExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpUriExtractorTest.java
@@ -35,11 +35,11 @@ public class HttpUriExtractorTest extends HttpUriExtractor {
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
                     Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                    assertEquals("Input is not a valid request", exception.getMessage());
+                    assertEquals("Input is not a valid request.", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Input is not a valid HTTP Request", exception.getMessage());
+                assertEquals("Input is not a valid HTTP request.", exception.getMessage());
                 }
             }
             else{

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpUriExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpUriExtractorTest.java
@@ -34,16 +34,16 @@ public class HttpUriExtractorTest extends HttpUriExtractor {
             this.checkbox.setSelected(res.getValue1());
             if (res.getValue2()) {
                 if(messageType == MessageType.REQUEST) {
-                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                    Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                     assertEquals("Input is not a valid request", exception.getMessage());
                 }
                 if(messageType == MessageType.RESPONSE) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Input is not a valid HTTP Request", exception.getMessage());
                 }
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpXmlExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpXmlExtractorTest.java
@@ -32,7 +32,7 @@ public class HttpXmlExtractorTest extends HttpXmlExtractor {
             this.fieldTxt.setText(res.getValue1());
             if (res.getValue2()) {
                 Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
-                assertEquals("Input is not a valid request", exception.getMessage());
+                assertEquals("XML element not found.", exception.getMessage());
             }
             else{
                 assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
@@ -136,9 +136,8 @@ public class HttpXmlExtractorTest extends HttpXmlExtractor {
                     </Tag2>
                 </RootTag>
                 """;
-        String reqOut3 = "";
         String reqTag3 = "";
-        Triplet<String, String,  Boolean> reqTriplet3 = new Triplet<String, String, Boolean>(reqOut3, reqTag3, false);
+        Triplet<String, String,  Boolean> reqTriplet3 = new Triplet<String, String, Boolean>(reqIn3, reqTag3, false);
 
         // HTTP Response && param empty
         String resIn3 = """
@@ -154,9 +153,8 @@ public class HttpXmlExtractorTest extends HttpXmlExtractor {
                     </Tag2>
                 </RootTag>
                 """;
-        String resOut3 = "";
         String resTag3 = "";
-        Triplet<String, String, Boolean> resTriplet3 = new Triplet<String, String, Boolean>(resOut3, resTag3, false);
+        Triplet<String, String, Boolean> resTriplet3 = new Triplet<String, String, Boolean>(resIn3, resTag3, false);
 
         // HTTP Request && param incorrect
         String reqIn4 = """

--- a/src/test/java/de/usd/cstchef/operations/extractors/HttpXmlExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/HttpXmlExtractorTest.java
@@ -14,7 +14,6 @@ import burp.CstcObjectFactory;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.utils.UnitTestObjectFactory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.OperationCategory;
 
 
@@ -30,14 +29,13 @@ public class HttpXmlExtractorTest extends HttpXmlExtractor {
             Triplet<String, String, Boolean> res = inputs.get(inp);
             ByteArray inputArray = factory.createByteArray(inp);
             ByteArray outputArray = factory.createByteArray(res.getValue0());
-            MessageType messageType = parseMessageType(inputArray);
             this.fieldTxt.setText(res.getValue1());
             if (res.getValue2()) {
-                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray, messageType));
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> perform(inputArray));
                 assertEquals("Input is not a valid request", exception.getMessage());
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, messageType).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/JsonExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/JsonExtractorTest.java
@@ -31,11 +31,11 @@ public class JsonExtractorTest extends JsonExtractor {
             ByteArray outputArray = factory.createByteArray(res.getValue0());
             this.fieldTxt.setText(res.getValue1());
             if (res.getValue2()) {
-                Exception exception = assertThrows(com.jayway.jsonpath.PathNotFoundException.class, () -> perform(inputArray, null));
+                Exception exception = assertThrows(com.jayway.jsonpath.PathNotFoundException.class, () -> perform(inputArray));
                 assertEquals(res.getValue3(), exception.getMessage());
             }
             else{
-                assertArrayEquals(outputArray.getBytes(), perform(inputArray, null).getBytes());
+                assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
             }
         }
     }

--- a/src/test/java/de/usd/cstchef/operations/extractors/RegexExtractorTest.java
+++ b/src/test/java/de/usd/cstchef/operations/extractors/RegexExtractorTest.java
@@ -1,7 +1,5 @@
 package de.usd.cstchef.operations.extractors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.util.HashMap;
@@ -14,7 +12,6 @@ import burp.CstcObjectFactory;
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation.OperationInfos;
 import de.usd.cstchef.utils.UnitTestObjectFactory;
-import de.usd.cstchef.Utils.MessageType;
 import de.usd.cstchef.operations.OperationCategory;
 
 
@@ -33,7 +30,7 @@ public class RegexExtractorTest extends RegexExtractor {
             ByteArray outputArray = factory.createByteArray(res.getValue0());
             this.regexTxt.setText(res.getValue1());
             this.outputBox.setSelectedItem(res.getValue2() ? "List matches" : "List capture groups");
-            assertArrayEquals(outputArray.getBytes(), perform(inputArray, null).getBytes());
+            assertArrayEquals(outputArray.getBytes(), perform(inputArray).getBytes());
         }
     }
 

--- a/src/test/java/de/usd/cstchef/operations/utils/MessageParsingTest.java
+++ b/src/test/java/de/usd/cstchef/operations/utils/MessageParsingTest.java
@@ -72,7 +72,7 @@ public class MessageParsingTest extends Operation
     }
 
     @Override
-    protected ByteArray perform(ByteArray input, MessageType messageType) throws Exception {
+    protected ByteArray perform(ByteArray input) throws Exception {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'perform'");
     }


### PR DESCRIPTION
Hi :wave: 
We updated our CSTC extension to version 1.3.5. It includes lots of improvements and new operations. A detailed Changelog is included below:

## Changelog v1.3.5

### Added

* Add Remove HTTP Header Operation

### Changed

* Refactor Send Plain Request Operation 
* Refactor Request Builder Operation to allow all HTTP verbs 
* Refactor Set HTTP Cookie Operation 
* Refactor HTTP Cookie Extractor Operation
* Refactor HTML Encode Operation
* Refactor HTML Decode Operation 
* Refactor HTTP Body Extractor Operation
* Refactor Substring Operation
* Change Recipe Panel to bake empty input 
* Change multiple operations to handle empty input 
* Change context menu items to not bake recipes when selected 
* Refactor Operations Tree to be the same for all Recipe Panel 
* Change operations perform method to parse the message type of its input 
* Add checkbox to Write File Operation to make the new line optional 

### Fixed 

* Fix several issues in relation of missing JSON fields in dated recipes
* Fix recipes being applied again on requests originating from the recipe itself (analog with responses) 
* Fix Request Builder Operation to add trailing line breaks 
* Fix logic error in JWT Sign Operation 
* Fix operations output Null Byte if an exception is thrown